### PR TITLE
Make small fixes to get tests running

### DIFF
--- a/cxx/distributions/base.hh
+++ b/cxx/distributions/base.hh
@@ -18,6 +18,6 @@ public:
     // A sample from the distribution we have accumulated so far.
     virtual double sample() = 0;
 
-    ~Distribution(){};
+    virtual ~Distribution() = default;
 };
 

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -425,7 +425,7 @@ public:
                 i_list = {0};
             } else {
                 auto tables_weights = domain->tables_weights();
-                auto Z = log(1 + domain->crp.N);
+                auto Z = log(domain->crp.alpha + domain->crp.N);
                 int idx = 0;
                 for (const auto &[t, w] : tables_weights) {
                     t_list.push_back(t);
@@ -621,7 +621,7 @@ public:
                     i_list = {0};
                 } else {
                     auto tables_weights = domain->tables_weights();
-                    auto Z = log(1 + domain->crp.N);
+                    auto Z = log(domain->crp.alpha + domain->crp.N);
                     int idx = 0;
                     for (const auto &[t, w] : tables_weights) {
                         t_list.push_back(t);

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -58,11 +58,11 @@ int main(int argc, char **argv) {
 
     map<int, map<int, double>> expected_p0 {
         {0,     { {0, 1},   {10, 1},    {100, .5} } },
-        {10,    { {0, 0},   {10, 0},    {100, .5} } },
+        {20,    { {0, 0},   {10, 0},    {100, .5} } },
         {100,   { {0, .66}, {10, .66},  {100, .5} } },
     };
 
-    vector<vector<int>> indexes {{0, 10, 100}, {0, 10, 100}};
+    vector<vector<int>> indexes {{0, 20, 100}, {0, 10, 100}};
     for (const auto &l : product(indexes)) {
         assert(l.size() == 2);
         auto x1 = l.at(0);

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -56,13 +56,20 @@ int main(int argc, char **argv) {
     std::cout << "writing clusters to " << path_clusters << std::endl;
     to_txt(path_clusters, irm, encoding);
 
+    auto item_to_code = std::get<0>(encoding);
+    auto code_item_0_D1 = item_to_code.at("D1").at("0");
+    auto code_item_10_D1 = item_to_code.at("D1").at("10");
+    auto code_item_0_D2 = item_to_code.at("D2").at("0");
+    auto code_item_10_D2 = item_to_code.at("D2").at("10");
+    auto code_item_novel = 100;
+
     map<int, map<int, double>> expected_p0 {
-        {0,     { {0, 1},   {10, 1},    {100, .5} } },
-        {20,    { {0, 0},   {10, 0},    {100, .5} } },
-        {100,   { {0, .66}, {10, .66},  {100, .5} } },
+        {code_item_0_D1,     { {code_item_0_D2, 1},   {code_item_10_D2, 1},    {code_item_novel, .5} } },
+        {code_item_10_D1,    { {code_item_0_D2, 0},   {code_item_10_D2, 0},    {code_item_novel, .5} } },
+        {code_item_novel,    { {code_item_0_D2, .66}, {code_item_10_D2, .66},  {code_item_novel, .5} } },
     };
 
-    vector<vector<int>> indexes {{0, 20, 100}, {0, 10, 100}};
+    vector<vector<int>> indexes {{code_item_0_D1, code_item_10_D1, code_item_novel}, {code_item_0_D1, code_item_10_D2, code_item_novel}};
     for (const auto &l : product(indexes)) {
         assert(l.size() == 2);
         auto x1 = l.at(0);

--- a/src/hirm.py
+++ b/src/hirm.py
@@ -331,7 +331,7 @@ class Relation:
                 i_list = [0]
             else:
                 tables_weights = domain.tables_weights()
-                Z = math.log(1 + domain.crp.N)
+                Z = math.log(domain.crp.alpha + domain.crp.N)
                 t_list = tuple(tables_weights.keys())
                 w_list = tuple(math.log(x) - Z for x in tables_weights.values())
                 i_list = tuple(range(len(tables_weights)))
@@ -593,7 +593,7 @@ def logp_observations(observations):
             else:
                 tables_weights = domain.tables_weights()
                 t_list = tuple(tables_weights.keys())
-                Z = math.log(1 + domain.crp.N)
+                Z = math.log(domain.crp.alpha + domain.crp.N)
                 w_list = tuple(math.log(x) - Z for x in tables_weights.values())
                 i_list = tuple(range(len(tables_weights)))
             item_universe.add((domain.name, item))


### PR DESCRIPTION
This PR implements several small changes that I had to make in order to get `make tests` to run from start to finish:

* The Distribution base class's destructor is now `virtual`
* In the `logp` methods of `Relation` and `IRM`, there was a tacit assumption that `domain->crp.alpha` was equal to 1; now we use the actual value in `domain->crp.alpha` for each domain.
* The two-relation-IRM test file referred to item 10 in the data file using the integer 10, but should have used the integer 20, since "10" is introduced after 20 other items.

Presumably these tests used to run, so maybe some of these fixes are necessary only due to quirks on my machine? Curious to know if (1) the tests run for others *without* these changes; (2) whether these changes break anything for others.