### PR TITLE
Add a bigram distribution over strings.

### DIFF
--- a/cxx/distributions/base.hh
+++ b/cxx/distributions/base.hh
@@ -6,12 +6,12 @@ public:
     // N is the number of incorporated observations.
     int N = 0;
 
-    virtual void incorporate(SampleType x) = 0;
-    virtual void unincorporate(SampleType x) = 0;
+    virtual void incorporate(const SampleType& x) = 0;
+    virtual void unincorporate(const SampleType& x) = 0;
 
     // The log probability of x according to the distribution we have
     // accumulated so far.
-    virtual double logp(SampleType x) const = 0;
+    virtual double logp(const SampleType& x) const = 0;
 
     virtual double logp_score() const = 0;
 

--- a/cxx/distributions/beta_bernoulli.hh
+++ b/cxx/distributions/beta_bernoulli.hh
@@ -14,19 +14,19 @@ public:
     BetaBernoulli(PRNG *prng) {
         this->prng = prng;
     }
-    void incorporate(double x){
+    void incorporate(const double& x){
         assert(x == 0 || x == 1);
         N += 1;
         s += x;
     }
-    void unincorporate(double x) {
+    void unincorporate(const double& x) {
         assert(x == 0 || x ==1);
         N -= 1;
         s -= x;
         assert(0 <= s);
         assert(0 <= N);
     }
-    double logp(double x) const {
+    double logp(const double& x) const {
         double log_denom = log(N + alpha + beta);
         if (x == 1) { return log(s + alpha) - log_denom; }
         if (x == 0) { return log(N - s + beta) - log_denom; }

--- a/cxx/distributions/bigram.hh
+++ b/cxx/distributions/bigram.hh
@@ -1,0 +1,88 @@
+// Copyright 2024
+// See LICENSE.txt
+
+#pragma once
+#include "base.hh"
+#include "dirichlet_categorical.hh"
+
+class Bigram : public Distribution<std::string> {
+private:
+    void assert_valid_char(const char c) const {
+        assert(c >= ' ' && c <= '~');
+    }
+    size_t char_to_index(const char c) const {
+        assert_valid_char(c);
+        return c - ' ';
+    }
+    char index_to_char(const size_t i) const {
+        const char c = i + ' ';
+        assert_valid_char(c);
+        return c;
+    }
+    std::vector<size_t> string_to_indices(const std::string& str) const {
+        // Convert the string to a vector of indices between 0 and `num_chars`,
+        // with a start/stop symbol at the beginning/end.
+        std::vector<size_t> inds = {num_chars};
+        for (const char& c : str) {
+            inds.push_back(char_to_index(c));
+        }
+        inds.push_back(num_chars);
+        return inds;
+    }
+public:
+    double alpha = 1;  // hyperparameter for all transition distributions.
+    size_t num_chars = '~' - ' ' + 1;  // printable ASCII without DEL.
+    std::vector<DirichletCategorical> transition_dists;
+    PRNG *prng;
+
+    Bigram(PRNG *prng) {
+        this->prng = prng;
+        const size_t total_chars = num_chars + 1;  // Include a start/stop symbol.
+
+        // The distribution at index `i` represents `p(x_{i+1} | x_i)`.
+        transition_dists.reserve(total_chars);
+        for (size_t i = 0; i != total_chars; ++i) {
+            transition_dists.emplace_back(prng, total_chars);
+        }
+    }
+    void incorporate(const std::string& x) {
+        const std::vector<size_t> indices = string_to_indices(x);
+        for (size_t i = 0; i != indices.size() - 1; ++i) {
+            transition_dists[indices[i]].incorporate(indices[i + 1]);
+        }
+    }
+    void unincorporate(const std::string& s) {
+        const std::vector<size_t> indices = string_to_indices(s);
+        for (size_t i = 0; i != indices.size() - 1; ++i) {
+            transition_dists[indices[i]].unincorporate(indices[i + 1]);
+        }
+    }
+    double logp(const std::string& s) const {
+        const std::vector<size_t> indices = string_to_indices(s);
+        double total_logp = 0.0;
+        for (size_t i = 0; i != indices.size() - 1; ++i) {
+            total_logp += transition_dists[indices[i]].logp(indices[i + 1]);
+        }
+        return total_logp;
+    }
+    double logp_score() const {
+        return std::transform_reduce(
+            transition_dists.cbegin(), 
+            transition_dists.cend(), 
+            0, 
+            std::plus{},
+            [&](auto d) -> double {return d.logp_score(); }
+        );
+    }
+    std::string sample() {
+        std::string sampled_string;
+        // Sample the first character conditioned on the stop/start symbol.
+        size_t current_ind = transition_dists[num_chars].sample();
+        // Sample additional characters until the stop/start symbol is sampled.
+        while (current_ind != num_chars) {
+            sampled_string += index_to_char(current_ind);
+            current_ind = transition_dists[current_ind].sample();
+        }
+        return sampled_string;
+    }
+};

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -16,12 +16,12 @@ public:
         counts = std::vector<int>(k, 0);
         n = 0;
     }
-    void incorporate(double x) {
+    void incorporate(const double& x) {
         assert(x >= 0 && x < counts.size());
         counts[size_t(x)] += 1;
         ++n;
     }
-    void unincorporate(double x) {
+    void unincorporate(const double& x) {
         const size_t y = x;
         assert(y < counts.size());
         counts[y] -= 1;
@@ -29,7 +29,7 @@ public:
         assert(0 <= counts[y]);
         assert(0 <= n);
     }
-    double logp(double x) const {
+    double logp(const double& x) const {
         assert(x >= 0 && x < counts.size());
         const double numer = log(alpha + counts[size_t(x)]);
         const double denom = log(n + alpha * counts.size());
@@ -43,7 +43,7 @@ public:
             counts.cend(), 
             0, 
             std::plus{},
-            [&](size_t y) -> double {return lgamma(counts[y] + alpha); }
+            [&](size_t y) -> double {return lgamma(y + alpha); }
         );
         return lgamma(a) - lgamma(a + n) + lg - k * lgamma(alpha);
     }
@@ -58,8 +58,4 @@ public:
         int idx = choice(weights, prng);
         return double(idx);
     }
-
-    // Disable copying.
-    DirichletCategorical & operator=(const DirichletCategorical&) = delete;
-    DirichletCategorical(const DirichletCategorical&) = delete;
 };

--- a/cxx/distributions/normal.hh
+++ b/cxx/distributions/normal.hh
@@ -22,14 +22,14 @@ public:
         this->prng = prng;
     }
 
-    void incorporate(double x){
+    void incorporate(const double& x){
         N += 1;
         double old_mean = mean;
         mean += (x - mean) / N;
         var += (x - mean) * (x - old_mean);
     }
 
-    void unincorporate(double x) {
+    void unincorporate(const double& x) {
         int old_N = N;
         N -= 1;
         double old_mean = mean;
@@ -37,7 +37,7 @@ public:
         var -= (x - mean) * (x - old_mean);
     }
 
-    double logp(double x) const {
+    double logp(const double& x) const {
         double y = (x - mean);
         return -0.5 * (y * y / var + log(var) + log(M_2PI));
     }

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -7,6 +7,7 @@
 #include "util_math.hh"
 #include "distributions/base.hh"
 #include "distributions/beta_bernoulli.hh"
+#include "distributions/bigram.hh"
 #include "distributions/dirichlet_categorical.hh"
 
 typedef int T_item;

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -44,6 +44,18 @@ int main(int argc, char **argv) {
     }
     printf("\n");
 
+    Bigram bg (&prng);
+    bg.incorporate("foo");
+    bg.incorporate("foo");
+    bg.incorporate("_Hello!~");
+    bg.unincorporate("foo");
+    printf("%f\n", exp(bg.logp("bar")));
+    printf("%f\n", exp(bg.logp_score()));
+    for (int i = 0; i < 10; i++) {
+        printf("%s\n", bg.sample().c_str());
+    }
+    printf("\n");
+
     CRP crp (&prng);
     crp.alpha = 1.5;
     printf("starting crp\n");


### PR DESCRIPTION
This adds a minimal bigram distribution over strings (#7 ), for now assuming the alphabet consists of printable ASCII characters.  

I’m not at all confident in the `logp_score` implementation (summing the logp_scores of each conditional distribution), so I’d appreciate an extra pair of eyes on that especially.
