### PR TITLE
Support different relation/distribution types using std::variant.

### DIFF
--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -64,7 +64,8 @@ cc_library(
 
 cc_library(
     name = "normal",
-    srcs = ["normal.hh"],
+    hdrs = ["normal.hh"],
+    srcs = ["normal.cc"],
     visibility = ["//:__subpackages__"],
     deps = [
         ":base",

--- a/cxx/distributions/adapter.hh
+++ b/cxx/distributions/adapter.hh
@@ -11,50 +11,52 @@
 
 #include "distributions/base.hh"
 
-template <typename SampleType = double>
+template <typename S = double>
 class DistributionAdapter : Distribution<std::string> {
  public:
   // The underlying distribution that is being adapted.  We own the
   // underlying Distribution.
-  Distribution<SampleType>* d;
+  Distribution<S>* d;
 
-  DistributionAdapter(Distribution<SampleType>* dd) : d(dd) {};
+  DistributionAdapter(Distribution<S>* dd) : d(dd) {};
 
-  SampleType from_string(const std::string& x) const {
-    SampleType s;
+  S from_string(const std::string& x) const {
+    S s;
     std::istringstream(x) >> s;
     return s;
   }
 
-  std::string to_string(const SampleType& s) const {
+  std::string to_string(const S& s) const {
     std::ostringstream os;
     os << s;
     return os.str();
   }
 
   void incorporate(const std::string& x) {
-    SampleType s = from_string(x);
+    S s = from_string(x);
     d->incorporate(s);
   }
 
   void unincorporate(const std::string& x) {
-    SampleType s = from_string(x);
+    S s = from_string(x);
     d->unincorporate(s);
   }
 
   double logp(const std::string& x) const {
-    SampleType s = from_string(x);
+    S s = from_string(x);
     return d->logp(s);
   }
 
   double logp_score() const { return d->logp_score(); }
 
   std::string sample() {
-    SampleType s = d->sample();
+    S s = d->sample();
     return to_string(s);
   }
 
-  void transition_hyperparameters() { d->transition_hyperparameters(); }
+  void transition_hyperparameters() {
+    d->transition_hyperparameters();
+  }
 
   ~DistributionAdapter() { delete d; }
 };

--- a/cxx/distributions/base.hh
+++ b/cxx/distributions/base.hh
@@ -1,24 +1,25 @@
 #pragma once
 
-template <typename SampleType = double>
+template <typename T>
 class Distribution {
   // Abstract base class for probability distributions in HIRM.
  public:
+  typedef T SampleType;
   // N is the number of incorporated observations.
   int N = 0;
 
   // Accumulate x.
-  virtual void incorporate(const SampleType& x) = 0;
+  virtual void incorporate(const T& x) = 0;
 
   // Undo the accumulation of x.  Should only be called with x's that
   // have been previously passed to incorporate().
-  virtual void unincorporate(const SampleType& x) = 0;
+  virtual void unincorporate(const T& x) = 0;
 
   // The log probability of x according to the posterior predictive
   // distribution:  log P(x | incorporated_data), where P(x | data) =
   // \integral_{theta} P(x | theta ) P(theta | data) dtheta
   // and theta are the parameters of the distribution.
-  virtual double logp(const SampleType& x) const = 0;
+  virtual double logp(const T& x) const = 0;
 
   // The log probability of the data we have accumulated so far according
   // to the prior:  log P(data | alpha) where alpha is the vector of
@@ -29,7 +30,7 @@ class Distribution {
   // A sample from the predictive distribution.
   // TODO(thomaswc): Consider refactoring so that this takes a
   // PRNG parameter.
-  virtual SampleType sample() = 0;
+  virtual T sample() = 0;
 
   // Transition the hyperparameters.  The probability of transitioning to
   // a particular set of hyperparameters should be proportional to

--- a/cxx/distributions/bigram.hh
+++ b/cxx/distributions/bigram.hh
@@ -53,6 +53,7 @@ class Bigram : public Distribution<std::string> {
     for (size_t i = 0; i != indices.size() - 1; ++i) {
       transition_dists[indices[i]].incorporate(indices[i + 1]);
     }
+    ++N;
   }
 
   void unincorporate(const std::string& s) {
@@ -60,6 +61,7 @@ class Bigram : public Distribution<std::string> {
     for (size_t i = 0; i != indices.size() - 1; ++i) {
       transition_dists[indices[i]].unincorporate(indices[i + 1]);
     }
+    --N;
   }
 
   double logp(const std::string& s) const {

--- a/cxx/distributions/bigram_test.cc
+++ b/cxx/distributions/bigram_test.cc
@@ -9,43 +9,46 @@ namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
   std::mt19937 prng;
-  Bigram bb(&prng);
+  Bigram bg(&prng);
 
-  bb.incorporate("hello");
-  bb.incorporate("world");
-  bb.unincorporate("hello");
-  bb.incorporate("train");
-  bb.unincorporate("world");
+  bg.incorporate("hello");
+  bg.incorporate("world");
+  BOOST_TEST(bg.N == 2);
+  bg.unincorporate("hello");
+  BOOST_TEST(bg.N == 1);
+  bg.incorporate("train");
+  bg.unincorporate("world");
+  BOOST_TEST(bg.N == 1);
 
-  BOOST_TEST(bb.logp("test") == -22.169938638053061, tt::tolerance(1e-6));
-  BOOST_TEST(bb.logp_score() == -27.386089148807059, tt::tolerance(1e-6));
+  BOOST_TEST(bg.logp("test") == -22.169938638053061, tt::tolerance(1e-6));
+  BOOST_TEST(bg.logp_score() == -27.386089148807059, tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(test_set_alpha) {
   std::mt19937 prng;
-  Bigram bb(&prng);
+  Bigram bg(&prng);
 
-  bb.incorporate("hello");
-  double first_lp = bb.logp_score();
+  bg.incorporate("hello");
+  double first_lp = bg.logp_score();
 
-  bb.set_alpha(2.0);
-  for (auto trans_dist : bb.transition_dists) {
+  bg.set_alpha(2.0);
+  for (auto trans_dist : bg.transition_dists) {
     BOOST_TEST(trans_dist.alpha == 2.0);
   }
 
-  BOOST_TEST(first_lp != bb.logp_score(), tt::tolerance(1e-6));
+  BOOST_TEST(first_lp != bg.logp_score(), tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   std::mt19937 prng;
-  Bigram bb(&prng);
+  Bigram bg(&prng);
 
-  bb.transition_hyperparameters();
+  bg.transition_hyperparameters();
   for (int i = 0; i < 100; ++i) {
-    bb.incorporate("abcdefghijklmnopqrstuvwxyz");
+    bg.incorporate("abcdefghijklmnopqrstuvwxyz");
   }
 
-  bb.transition_hyperparameters();
+  bg.transition_hyperparameters();
 
-  BOOST_TEST(bb.alpha < 1.0);
+  BOOST_TEST(bg.alpha < 1.0);
 }

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -24,7 +24,6 @@ class DirichletCategorical : public Distribution<double> {
                        int k) {  // k is number of categories
     this->prng = prng;
     counts = std::vector<int>(k, 0);
-    N = 0;
   }
   void incorporate(const double& x) {
     assert(x >= 0 && x < counts.size());

--- a/cxx/distributions/normal.cc
+++ b/cxx/distributions/normal.cc
@@ -1,0 +1,111 @@
+// Copyright 2024
+// See LICENSE.txt
+
+#include <cmath>
+#include <numbers>
+
+#include "normal.hh"
+
+double logZ(double r, double v, double s) {
+  return (v + 1.0) / 2.0 * log(2.0)
+      + 0.5 * log(std::numbers::pi)
+      - 0.5 * log(r)
+      - 0.5 * v * log(s)
+      + lgamma(0.5 * v);
+}
+
+void Normal::incorporate(const double &x){
+    ++N;
+    double old_mean = mean;
+    mean += (x - mean) / N;
+    var += (x - mean) * (x - old_mean);
+}
+
+void Normal::unincorporate(const double &x) {
+    int old_N = N;
+    --N;
+    if (N == 0) {
+      mean = 0.0;
+      var = 0.0;
+      return;
+    }
+    double old_mean = mean;
+    mean = (mean * old_N - x) / N;
+    var -= (x - mean) * (x - old_mean);
+}
+
+void Normal::posterior_hypers(double *mprime, double *sprime) const {
+  // r' = r + N
+  // m' = (r m + N mean) / (r + N)
+  // C = N (var + mean^2)
+  // s' = s + C + r m^2 - r' m' m'
+  double mdelta = r * (m - mean) / (r + N);
+  *mprime = mean + mdelta;
+  *sprime = s + r * (m * m - *mprime * *mprime) +
+            N * (var - 2 * mean * mdelta - mdelta * mdelta);
+}
+
+double Normal::logp(const double& x) const {
+  // Based on equation (13) of GaussianInverseGamma.pdf
+  double unused_mprime, sprime;
+  const_cast<Normal*>(this)->incorporate(x);
+  posterior_hypers(&unused_mprime, &sprime);
+  const_cast<Normal*>(this)->unincorporate(x);
+  double sprime2;
+  posterior_hypers(&unused_mprime, &sprime2);
+  return -0.5 * log(M_2PI)
+      + logZ(r + N + 1, v + N + 1, sprime)
+      - logZ(r + N, v + N, sprime2);
+}
+
+double Normal::logp_score() const {
+  // Based on equation (11) of GaussianInverseGamma.pdf
+  double unused_mprime, sprime;
+  posterior_hypers(&unused_mprime, &sprime);
+  return -0.5 * N * log(M_2PI)
+      + logZ(r + N, v + N, sprime)
+      - logZ(r, v, s);
+}
+
+double Normal::sample() {
+  double rn = r + N;
+  double nu = v + N;
+  double mprime, sprime;
+  posterior_hypers(&mprime, &sprime);
+  std::gamma_distribution<double> rho_dist(nu / 2.0, 2.0 / sprime);
+  double rho = rho_dist(*prng);
+  std::normal_distribution<double> mean_dist(mprime, 1.0 / sqrt(rho * rn));
+  double smean = mean_dist(*prng);
+  double std_dev = 1.0 / sqrt(rho);
+
+  std::normal_distribution<double> d(smean, std_dev);
+  return d(*prng);
+}
+
+void Normal::transition_hyperparameters() {
+  std::vector<double> logps;
+  std::vector<std::tuple<double, double, double, double>> hypers;
+  for (double rt : R_GRID) {
+    for (double vt : V_GRID) {
+      for (double mt : M_GRID) {
+        for (double st : S_GRID) {
+          r = rt;
+          v = vt;
+          m = mt;
+          s = st;
+          double lp = logp_score();
+          if (!std::isnan(lp)) {
+            logps.push_back(logp_score());
+            hypers.push_back(std::make_tuple(r, v, m, s));
+          }
+        }
+      }
+    }
+  }
+
+  int i = sample_from_logps(logps, prng);
+  r = std::get<0>(hypers[i]);
+  v = std::get<1>(hypers[i]);
+  m = std::get<2>(hypers[i]);
+  s = std::get<3>(hypers[i]);
+}

--- a/cxx/distributions/normal.hh
+++ b/cxx/distributions/normal.hh
@@ -9,10 +9,6 @@
 #include "base.hh"
 #include "util_math.hh"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338327950288419716939937510
-#endif
-
 #ifndef M_2PI
 #define M_2PI 6.28318530717958647692528676655
 #endif
@@ -26,10 +22,7 @@
 #define S_GRID \
   { 0.5, 1.0, 2.0 }
 
-double logZ(double r, double v, double s) {
-  return (v + 1.0) / 2.0 * log(2.0) + 0.5 * log(M_PI) - 0.5 * log(r) -
-         0.5 * v * log(s) + lgamma(0.5 * v);
-}
+double logZ(double r, double v, double s);
 
 class Normal : public Distribution<double> {
  public:
@@ -53,98 +46,19 @@ class Normal : public Distribution<double> {
   // Normal does not take ownership of prng.
   Normal(std::mt19937* prng) { this->prng = prng; }
 
-  void incorporate(const double& x) {
-    ++N;
-    double old_mean = mean;
-    mean += (x - mean) / N;
-    var += (x - mean) * (x - old_mean);
-  }
+  void incorporate(const double& x);
 
-  void unincorporate(const double& x) {
-    int old_N = N;
-    --N;
-    if (N == 0) {
-      mean = 0.0;
-      var = 0.0;
-      return;
-    }
-    double old_mean = mean;
-    mean = (mean * old_N - x) / N;
-    var -= (x - mean) * (x - old_mean);
-  }
+  void unincorporate(const double& x);
 
-  void posterior_hypers(double* mprime, double* sprime) const {
-    // r' = r + N
-    // m' = (r m + N mean) / (r + N)
-    // C = N (var + mean^2)
-    // s' = s + C + r m^2 - r' m' m'
-    double mdelta = r * (m - mean) / (r + N);
-    *mprime = mean + mdelta;
-    *sprime = s + r * (m * m - *mprime * *mprime) +
-              N * (var - 2 * mean * mdelta - mdelta * mdelta);
-  }
+  void posterior_hypers(double *mprime, double *sprime) const;
 
-  double logp(const double& x) const {
-    // Based on equation (13) of GaussianInverseGamma.pdf
-    double unused_mprime, sprime;
-    const_cast<Normal*>(this)->incorporate(x);
-    posterior_hypers(&unused_mprime, &sprime);
-    const_cast<Normal*>(this)->unincorporate(x);
-    double sprime2;
-    posterior_hypers(&unused_mprime, &sprime2);
-    return -0.5 * log(M_2PI) + logZ(r + N + 1, v + N + 1, sprime) -
-           logZ(r + N, v + N, sprime2);
-  }
+  double logp(const double& x) const;
 
-  double logp_score() const {
-    // Based on equation (11) of GaussianInverseGamma.pdf
-    double unused_mprime, sprime;
-    posterior_hypers(&unused_mprime, &sprime);
-    return -0.5 * N * log(M_2PI) + logZ(r + N, v + N, sprime) - logZ(r, v, s);
-  }
+  double logp_score() const;
 
-  double sample() {
-    double rn = r + N;
-    double nu = v + N;
-    double mprime, sprime;
-    posterior_hypers(&mprime, &sprime);
-    std::gamma_distribution<double> rho_dist(nu / 2.0, 2.0 / sprime);
-    double rho = rho_dist(*prng);
-    std::normal_distribution<double> mean_dist(mprime, 1.0 / sqrt(rho * rn));
-    double smean = mean_dist(*prng);
-    double std_dev = 1.0 / sqrt(rho);
+  double sample();
 
-    std::normal_distribution<double> d(smean, std_dev);
-    return d(*prng);
-  }
-
-  void transition_hyperparameters() {
-    std::vector<double> logps;
-    std::vector<std::tuple<double, double, double, double>> hypers;
-    for (double rt : R_GRID) {
-      for (double vt : V_GRID) {
-        for (double mt : M_GRID) {
-          for (double st : S_GRID) {
-            r = rt;
-            v = vt;
-            m = mt;
-            s = st;
-            double lp = logp_score();
-            if (!std::isnan(lp)) {
-              logps.push_back(logp_score());
-              hypers.push_back(std::make_tuple(r, v, m, s));
-            }
-          }
-        }
-      }
-    }
-
-    int i = sample_from_logps(logps, prng);
-    r = std::get<0>(hypers[i]);
-    v = std::get<1>(hypers[i]);
-    m = std::get<2>(hypers[i]);
-    s = std::get<3>(hypers[i]);
-  }
+  void transition_hyperparameters();
 
   // Disable copying.
   Normal& operator=(const Normal&) = delete;

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -43,11 +43,15 @@ void single_step_irm_inference(IRM* irm, double& t_total, bool verbose) {
   }
   // TRANSITION DISTRIBUTION HYPERPARAMETERS.
   for (const auto& [r, relation] : irm->relations) {
-    for (const auto& [c, distribution] : relation->clusters) {
-      clock_t t = clock();
-      distribution->transition_hyperparameters();
-      REPORT_SCORE(verbose, t, t_total, irm);
-    }
+    std::visit(
+        [&](auto r) {
+          for (const auto& [c, distribution] : r->clusters) {
+            clock_t t = clock();
+            distribution->transition_hyperparameters();
+            REPORT_SCORE(verbose, t, t_total, irm);
+          }
+        },
+        relation);
   }
   // TRANSITION ALPHA.
   for (const auto& [d, domain] : irm->domains) {

--- a/cxx/integration_tests.sh
+++ b/cxx/integration_tests.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Run integration test suite
-bazel build :hirm tests:test_hirm_animals tests:test_irm_two_relations
+bazel build :hirm tests:test_hirm_animals tests:test_irm_two_relations tests:test_misc
 ./bazel-bin/tests/test_hirm_animals
 ./bazel-bin/tests/test_irm_two_relations
+./bazel-bin/tests/test_misc
 ./bazel-bin/hirm --mode=irm --iters=5 assets/animals.binary
 ./bazel-bin/hirm --seed=1 --iters=5 assets/animals.unary
 ./bazel-bin/hirm --iters=5 --load=assets/animals.unary.1.hirm assets/animals.unary

--- a/cxx/tests/BUILD
+++ b/cxx/tests/BUILD
@@ -17,3 +17,13 @@ cc_binary(
         "//distributions",
     ],
 )
+
+cc_binary(
+    name = "test_misc",
+    srcs = ["test_misc.cc"],
+    deps = [
+        "//:headers",
+        "//:util_io",
+        "//distributions",
+    ],
+)

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -29,10 +29,10 @@ int main(int argc, char** argv) {
   printf("--- initialized HIRM --- \n");
   incorporate_observations(hirm, encoding_unary, observations_unary);
   printf("--- incorporated observations --- \n");
-  int n_obs_unary = 0;
+  size_t n_obs_unary = 0;
   for (const auto& [z, irm] : hirm.irms) {
     for (const auto& [r, relation] : irm->relations) {
-      n_obs_unary += relation->data.size();
+      n_obs_unary += std::visit([](const auto r) {return r->data.size();}, relation);
     }
   }
   assert(n_obs_unary == std::ssize(observations_unary));
@@ -136,8 +136,9 @@ int main(int argc, char** argv) {
       assert(dm->crp.alpha == dx->crp.alpha);
     }
     // Check relations agree.
-    for (const auto& [r, rm] : irm->relations) {
-      auto rx = irx->relations.at(r);
+    for (const auto& [r, rm_var] : irm->relations) {
+      auto rx = std::get<Relation<BetaBernoulli>*>(irx->relations.at(r));
+      auto rm = std::get<Relation<BetaBernoulli>*>(rm_var);
       assert(rm->data == rx->data);
       assert(rm->data_r == rx->data_r);
       assert(rm->clusters.size() == rx->clusters.size());

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -15,6 +15,8 @@
 #include "util_io.hh"
 #include "util_math.hh"
 
+using T_r = Relation<BetaBernoulli>*;
+
 int main(int argc, char** argv) {
   std::string path_base = "assets/two_relations";
   int seed = 1;
@@ -79,10 +81,10 @@ int main(int argc, char** argv) {
     assert(l.size() == 2);
     auto x1 = l.at(0);
     auto x2 = l.at(1);
-    auto p0 = irm.relations.at("R1")->logp({x1, x2}, 0);
-    auto p0_irm = irm.logp({{"R1", {x1, x2}, 0}});
+    auto p0 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, 0.);
+    auto p0_irm = irm.logp({{"R1", {x1, x2}, 0.}});
     assert(abs(p0 - p0_irm) < 1e-10);
-    auto p1 = irm.relations.at("R1")->logp({x1, x2}, 1);
+    auto p1 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, 1.);
     auto Z = logsumexp({p0, p1});
     assert(abs(Z) < 1e-10);
     assert(abs(exp(p0) - expected_p0[x1].at(x2)) < .1);
@@ -93,10 +95,10 @@ int main(int argc, char** argv) {
     auto x1 = l.at(0);
     auto x2 = l.at(1);
     auto x3 = l.at(2);
-    auto p00 = irm.logp({{"R1", {x1, x2}, 0}, {"R1", {x1, x3}, 0}});
-    auto p01 = irm.logp({{"R1", {x1, x2}, 0}, {"R1", {x1, x3}, 1}});
-    auto p10 = irm.logp({{"R1", {x1, x2}, 1}, {"R1", {x1, x3}, 0}});
-    auto p11 = irm.logp({{"R1", {x1, x2}, 1}, {"R1", {x1, x3}, 1}});
+    auto p00 = irm.logp({{"R1", {x1, x2}, 0.}, {"R1", {x1, x3}, 0.}});
+    auto p01 = irm.logp({{"R1", {x1, x2}, 0.}, {"R1", {x1, x3}, 1.}});
+    auto p10 = irm.logp({{"R1", {x1, x2}, 1.}, {"R1", {x1, x3}, 0.}});
+    auto p11 = irm.logp({{"R1", {x1, x2}, 1.}, {"R1", {x1, x3}, 1.}});
     auto Z = logsumexp({p00, p01, p10, p11});
     assert(abs(Z) < 1e-10);
   }
@@ -122,8 +124,10 @@ int main(int argc, char** argv) {
   }
   // Check relations agree.
   for (const auto& r : {"R1", "R2"}) {
-    auto rm = irm.relations.at(r);
-    auto rx = irx.relations.at(r);
+    auto rm_var = irm.relations.at(r);
+    auto rx_var = irx.relations.at(r);
+    T_r rm = std::get<T_r>(rm_var);
+    T_r rx = std::get<T_r>(rx_var);
     assert(rm->data == rx->data);
     assert(rm->data_r == rx->data_r);
     assert(rm->clusters.size() == rx->clusters.size());


### PR DESCRIPTION
Non-Bernoulli models are still pretty sparsely tested (I added some minimal coverage in `test_misc`) but I think this is in a reviewable state.

I'll add support for Categoricals in a follow-up. Plumbing the `num_categories` parameter through is a little tricky (one idea is to include the number of categories in the distribution name, e.g. `categorical12` and then parse it inside of `Relation` when we need a new distribution instance.)

I changed `SampleType` to `S` in `DistributionAdapter` (which was an alternative approach to generalizing distribution types, which I think we no longer need assuming this PR looks good) due to a name collision with the `SampleType` that I put in the base class. I moved function/method definitions from `normal.hh` to `normal.cc` to avoid multiple-definition errors for `logZ`.