### PR TITLE
Add marginal tests

### DIFF
--- a/cxx/.bazelrc
+++ b/cxx/.bazelrc
@@ -1,2 +1,3 @@
 build --cxxopt=-std=c++20
 test --cxxopt=-std=c++20
+test --test_output=errors

--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -89,6 +89,7 @@ cc_test(
     deps = [
         ":beta_bernoulli",
         "@boost//:algorithm",
+        "@boost//:math",
         "@boost//:test",
     ],
 )
@@ -108,6 +109,7 @@ cc_test(
     srcs = ["dirichlet_categorical_test.cc"],
     deps = [
         ":dirichlet_categorical",
+        ":beta_bernoulli",
         "@boost//:algorithm",
         "@boost//:test",
     ],
@@ -119,6 +121,7 @@ cc_test(
     deps = [
         ":normal",
         "@boost//:algorithm",
+        "@boost//:math",
         "@boost//:test",
     ],
 )

--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -3,7 +3,10 @@
 #define BOOST_TEST_MODULE test BetaBernoulli
 
 #include "distributions/beta_bernoulli.hh"
+#include "util_math.hh"
 
+#include <boost/math/distributions/bernoulli.hpp>
+#include <boost/math/distributions/beta.hpp>
 #include <boost/test/included/unit_test.hpp>
 namespace tt = boost::test_tools;
 
@@ -13,12 +16,54 @@ BOOST_AUTO_TEST_CASE(test_simple) {
 
   bb.incorporate(1);
   bb.incorporate(0);
+  BOOST_TEST(bb.N == 2);
+
   bb.unincorporate(1);
+  BOOST_TEST(bb.N == 1);
+
   bb.incorporate(1);
   bb.unincorporate(0);
+  BOOST_TEST(bb.N == 1);
 
-  BOOST_TEST(bb.logp(1) == -0.4054651081081645, tt::tolerance(1e-6));
+  // We expect that this is log(Num ones + alpha) - log(N + alpha + beta) ==
+  // log(2) - log(3) = log(2/3)
+  BOOST_TEST(bb.logp(1) == log(2 / 3.), tt::tolerance(1e-6));
+  // We expect a 50% chance when we see a single observation, since alpha = beta
+  // = 1.
   BOOST_TEST(bb.logp_score() == -0.69314718055994529, tt::tolerance(1e-6));
+}
+
+BOOST_AUTO_TEST_CASE(test_against_boost) {
+  // Construct a biased estimator of the log_prob using Boost, and check that we
+  // are within tolerance.
+  std::mt19937 prng;
+  std::mt19937 prng2;
+  BetaBernoulli bb(&prng);
+  const int num_trials = 5000;
+
+  std::vector<double> beta_samples;
+  for (int j = 0; j < num_trials; ++j) {
+    double x = (std::gamma_distribution<double>(bb.alpha, 1.))(prng2);
+    double y = (std::gamma_distribution<double>(bb.beta, 1.))(prng2);
+    beta_samples.emplace_back(x / (x + y));
+  }
+
+  double accumulated_log_prob;
+  boost::math::beta_distribution<> beta_dist(bb.alpha, bb.beta);
+
+  for (int i = 0; i < 10; ++i) {
+    bb.incorporate(i % 2);
+    std::vector<double> average_log_prob;
+
+    for (double b : beta_samples) {
+      boost::math::bernoulli_distribution bernoulli_dist(b);
+      average_log_prob.emplace_back(log(
+          boost::math::pdf(
+              bernoulli_dist, static_cast<double>(i % 2)) / num_trials));
+    }
+    accumulated_log_prob += logsumexp(average_log_prob);
+    BOOST_TEST(bb.logp_score() == accumulated_log_prob, tt::tolerance(0.3));
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
@@ -33,6 +78,9 @@ BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
     bb.incorporate(1);
   }
 
+  BOOST_TEST(bb.N == 101);
   bb.transition_hyperparameters();
+  // Expect that since we saw a lot of 1's, that alpha will be much larger than
+  // beta.
   BOOST_TEST(bb.alpha > bb.beta);
 }

--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   BOOST_TEST(bb.logp(1) == log(2 / 3.), tt::tolerance(1e-6));
   // We expect a 50% chance when we see a single observation, since alpha = beta
   // = 1.
-  BOOST_TEST(bb.logp_score() == -0.69314718055994529, tt::tolerance(1e-6));
+  BOOST_TEST(bb.logp_score() == -std::numbers::ln2, tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(test_against_boost) {

--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -3,11 +3,12 @@
 #define BOOST_TEST_MODULE test BetaBernoulli
 
 #include "distributions/beta_bernoulli.hh"
-#include "util_math.hh"
 
 #include <boost/math/distributions/bernoulli.hpp>
 #include <boost/math/distributions/beta.hpp>
 #include <boost/test/included/unit_test.hpp>
+
+#include "util_math.hh"
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
@@ -57,17 +58,16 @@ BOOST_AUTO_TEST_CASE(test_against_boost) {
 
     for (double b : beta_samples) {
       boost::math::bernoulli_distribution bernoulli_dist(b);
-      average_log_prob.emplace_back(log(
-          boost::math::pdf(
-              bernoulli_dist, static_cast<double>(i % 2)) / num_trials));
+      average_log_prob.emplace_back(
+          log(boost::math::pdf(bernoulli_dist, static_cast<double>(i % 2)) /
+              num_trials));
     }
     accumulated_log_prob += logsumexp(average_log_prob);
     BOOST_TEST(bb.logp_score() == accumulated_log_prob, tt::tolerance(0.3));
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
-{
+BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   std::mt19937 prng;
   BetaBernoulli bb(&prng);
 

--- a/cxx/distributions/bigram.hh
+++ b/cxx/distributions/bigram.hh
@@ -47,18 +47,21 @@ class Bigram : public Distribution<std::string> {
       transition_dists.emplace_back(prng, total_chars);
     }
   }
+
   void incorporate(const std::string& x) {
     const std::vector<size_t> indices = string_to_indices(x);
     for (size_t i = 0; i != indices.size() - 1; ++i) {
       transition_dists[indices[i]].incorporate(indices[i + 1]);
     }
   }
+
   void unincorporate(const std::string& s) {
     const std::vector<size_t> indices = string_to_indices(s);
     for (size_t i = 0; i != indices.size() - 1; ++i) {
       transition_dists[indices[i]].unincorporate(indices[i + 1]);
     }
   }
+
   double logp(const std::string& s) const {
     const std::vector<size_t> indices = string_to_indices(s);
     double total_logp = 0.0;
@@ -73,11 +76,15 @@ class Bigram : public Distribution<std::string> {
     }
     return total_logp;
   }
+
   double logp_score() const {
-    return std::transform_reduce(
-        transition_dists.cbegin(), transition_dists.cend(), 0, std::plus{},
-        [&](auto d) -> double { return d.logp_score(); });
+    double logp = 0;
+    for (auto d : transition_dists) {
+      logp += d.logp_score();
+    }
+    return logp;
   }
+
   std::string sample() {
     std::string sampled_string;
     // TODO(emilyaf): Reconsider the reserved length and maybe enforce a

--- a/cxx/distributions/bigram.hh
+++ b/cxx/distributions/bigram.hh
@@ -79,7 +79,7 @@ class Bigram : public Distribution<std::string> {
 
   double logp_score() const {
     double logp = 0;
-    for (auto d : transition_dists) {
+    for (const auto& d : transition_dists) {
       logp += d.logp_score();
     }
     return logp;

--- a/cxx/distributions/bigram_test.cc
+++ b/cxx/distributions/bigram_test.cc
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   bb.unincorporate("world");
 
   BOOST_TEST(bb.logp("test") == -22.169938638053061, tt::tolerance(1e-6));
-  BOOST_TEST(bb.logp_score() == -24, tt::tolerance(1e-6));
+  BOOST_TEST(bb.logp_score() == -27.386089148807059, tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(test_set_alpha) {
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(test_set_alpha) {
     BOOST_TEST(trans_dist.alpha == 2.0);
   }
 
-  BOOST_TEST(first_lp != bb.logp_score());
+  BOOST_TEST(first_lp != bb.logp_score(), tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(transition_hyperparameters) {

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <random>
+#include <iostream>
 
 #include "base.hh"
 #include "util_math.hh"
@@ -16,7 +17,6 @@ class DirichletCategorical : public Distribution<double> {
  public:
   double alpha = 1;         // hyperparameter (applies to all categories)
   std::vector<int> counts;  // counts of observed categories
-  int n;                    // Total number of observations.
   std::mt19937* prng;
 
   // DirichletCategorical does not take ownership of prng.
@@ -24,34 +24,35 @@ class DirichletCategorical : public Distribution<double> {
                        int k) {  // k is number of categories
     this->prng = prng;
     counts = std::vector<int>(k, 0);
-    n = 0;
+    N = 0;
   }
   void incorporate(const double& x) {
     assert(x >= 0 && x < counts.size());
     counts[size_t(x)] += 1;
-    ++n;
+    ++N;
   }
   void unincorporate(const double& x) {
     const size_t y = x;
     assert(y < counts.size());
     counts[y] -= 1;
-    --n;
+    --N;
     assert(0 <= counts[y]);
-    assert(0 <= n);
+    assert(0 <= N);
   }
   double logp(const double& x) const {
     assert(x >= 0 && x < counts.size());
     const double numer = log(alpha + counts[size_t(x)]);
-    const double denom = log(n + alpha * counts.size());
+    const double denom = log(N + alpha * counts.size());
     return numer - denom;
   }
   double logp_score() const {
     const size_t k = counts.size();
     const double a = alpha * k;
-    const double lg = std::transform_reduce(
-        counts.cbegin(), counts.cend(), 0, std::plus{},
-        [&](size_t y) -> double { return lgamma(y + alpha); });
-    return lgamma(a) - lgamma(a + n) + lg - k * lgamma(alpha);
+    double lg = 0;
+    for (size_t x : counts) {
+      lg += lgamma(static_cast<double>(x) + alpha);
+    }
+    return lgamma(a) - lgamma(a + N) + lg - k * lgamma(alpha);
   }
   double sample() {
     std::vector<double> weights(counts.size());

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -4,8 +4,8 @@
 #pragma once
 #include <algorithm>
 #include <cassert>
-#include <random>
 #include <iostream>
+#include <random>
 
 #include "base.hh"
 #include "util_math.hh"

--- a/cxx/distributions/dirichlet_categorical_test.cc
+++ b/cxx/distributions/dirichlet_categorical_test.cc
@@ -3,8 +3,32 @@
 #define BOOST_TEST_MODULE test DirichletCategorical
 
 #include <boost/test/included/unit_test.hpp>
+#include "distributions/beta_bernoulli.hh"
 #include "distributions/dirichlet_categorical.hh"
 namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(test_matches_beta_bernoulli)
+{
+  std::mt19937 prng;
+  // 2-category Dirichlet Categorical is the same as a BetaBernoulli.
+  DirichletCategorical dc(&prng, 2);
+  BetaBernoulli bb(&prng);
+
+  for (int i = 0; i < 10; ++i) {
+    dc.incorporate(i % 2);
+    bb.incorporate(i % 2);
+  }
+  for (int i = 0; i < 10; i += 2) {
+    dc.unincorporate(i % 2);
+    bb.unincorporate(i % 2);
+  }
+
+  BOOST_TEST(dc.N == 5);
+
+  BOOST_TEST(dc.logp(1) == bb.logp(1), tt::tolerance(1e-6));
+  BOOST_TEST(dc.logp(0) == bb.logp(0), tt::tolerance(1e-6));
+  BOOST_TEST(dc.logp_score() == bb.logp_score(), tt::tolerance(1e-6));
+}
 
 BOOST_AUTO_TEST_CASE(test_simple)
 {
@@ -18,6 +42,7 @@ BOOST_AUTO_TEST_CASE(test_simple)
     dc.unincorporate(i);
   }
 
+  BOOST_TEST(dc.N == 5);
   BOOST_TEST(dc.logp(1) == -2.0149030205422647, tt::tolerance(1e-6));
   BOOST_TEST(dc.logp_score() == -12.389393702657209, tt::tolerance(1e-6));
 }
@@ -33,6 +58,7 @@ BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
     dc.incorporate(i % 10);
   }
 
+  BOOST_TEST(dc.N == 100);
   dc.transition_hyperparameters();
   BOOST_TEST(dc.alpha > 1.0);
 }

--- a/cxx/distributions/dirichlet_categorical_test.cc
+++ b/cxx/distributions/dirichlet_categorical_test.cc
@@ -2,13 +2,14 @@
 
 #define BOOST_TEST_MODULE test DirichletCategorical
 
-#include <boost/test/included/unit_test.hpp>
-#include "distributions/beta_bernoulli.hh"
 #include "distributions/dirichlet_categorical.hh"
+
+#include <boost/test/included/unit_test.hpp>
+
+#include "distributions/beta_bernoulli.hh"
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE(test_matches_beta_bernoulli)
-{
+BOOST_AUTO_TEST_CASE(test_matches_beta_bernoulli) {
   std::mt19937 prng;
   // 2-category Dirichlet Categorical is the same as a BetaBernoulli.
   DirichletCategorical dc(&prng, 2);
@@ -30,8 +31,7 @@ BOOST_AUTO_TEST_CASE(test_matches_beta_bernoulli)
   BOOST_TEST(dc.logp_score() == bb.logp_score(), tt::tolerance(1e-6));
 }
 
-BOOST_AUTO_TEST_CASE(test_simple)
-{
+BOOST_AUTO_TEST_CASE(test_simple) {
   std::mt19937 prng;
   DirichletCategorical dc(&prng, 10);
 
@@ -47,8 +47,7 @@ BOOST_AUTO_TEST_CASE(test_simple)
   BOOST_TEST(dc.logp_score() == -12.389393702657209, tt::tolerance(1e-6));
 }
 
-BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
-{
+BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   std::mt19937 prng;
   DirichletCategorical dc(&prng, 10);
 
@@ -62,4 +61,3 @@ BOOST_AUTO_TEST_CASE(test_transition_hyperparameters)
   dc.transition_hyperparameters();
   BOOST_TEST(dc.alpha > 1.0);
 }
-

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -3,9 +3,50 @@
 #define BOOST_TEST_MODULE test Normal
 
 #include "distributions/normal.hh"
+#include "util_math.hh"
 
+#include <boost/math/distributions/inverse_gamma.hpp>
+#include <boost/math/distributions/normal.hpp>
 #include <boost/test/included/unit_test.hpp>
 namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(test_against_boost) {
+  // Construct a biased estimator of the log_prob using Boost, and check that we
+  // are within tolerance.
+  std::mt19937 prng;
+  std::mt19937 prng2;
+  Normal nd(&prng);
+
+  std::vector<double> inverse_gamma_samples;
+  std::vector<double> normal_samples;
+  int num_trials = 5000;
+
+  for (int j = 0; j < num_trials; ++j) {
+    double x = 1. / (std::gamma_distribution<double>(nd.v, nd.s))(prng2);
+    inverse_gamma_samples.emplace_back(x);
+    double y = (std::normal_distribution<double>(nd.m, sqrt(x / nd.r))) (prng2);
+    normal_samples.emplace_back(y);
+  }
+
+  double accumulated_log_prob;
+  boost::math::inverse_gamma_distribution<> inv_gamma_dist(nd.v, nd.s);
+
+  for (int i = 0; i < 10; ++i) {
+    nd.incorporate(i);
+    std::vector<double> average_log_prob;
+
+    for (int j = 0; j < num_trials; ++j) {
+      double ig = inverse_gamma_samples[j];
+      double n = normal_samples[j];
+      boost::math::normal_distribution normal_dist(n, sqrt(ig));
+      average_log_prob.emplace_back(
+          log(boost::math::pdf(normal_dist, static_cast<double>(i)) / num_trials));
+    }
+    accumulated_log_prob += logsumexp(average_log_prob);
+    BOOST_TEST(nd.logp_score() == accumulated_log_prob, tt::tolerance(0.3));
+  }
+  BOOST_TEST(nd.N == 10);
+}
 
 BOOST_AUTO_TEST_CASE(simple) {
   std::mt19937 prng;
@@ -13,9 +54,14 @@ BOOST_AUTO_TEST_CASE(simple) {
 
   nd.incorporate(5.0);
   nd.incorporate(-2.0);
+  BOOST_TEST(nd.N == 2);
+
   nd.unincorporate(5.0);
   nd.incorporate(7.0);
+  BOOST_TEST(nd.N == 2);
+
   nd.unincorporate(-2.0);
+  BOOST_TEST(nd.N == 1);
 
   BOOST_TEST(nd.logp(6.0) == -2.7673076255063034, tt::tolerance(1e-6));
   BOOST_TEST(nd.logp_score() == -4.7299819282937534, tt::tolerance(1e-6));
@@ -28,6 +74,7 @@ BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {
   nd.incorporate(10.0);
   nd.unincorporate(10.0);
 
+  BOOST_TEST(nd.N == 0);
   BOOST_TEST(!std::isnan(nd.mean));
   BOOST_TEST(!std::isnan(nd.var));
 }
@@ -42,6 +89,7 @@ BOOST_AUTO_TEST_CASE(logp_before_incorporate) {
   nd.incorporate(5.0);
   nd.unincorporate(5.0);
 
+  BOOST_TEST(nd.N == 0);
   BOOST_TEST(nd.logp(6.0) == -4.4357424552958129, tt::tolerance(1e-6));
   BOOST_TEST(nd.logp_score() == 0.0, tt::tolerance(1e-6));
 }

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -3,11 +3,12 @@
 #define BOOST_TEST_MODULE test Normal
 
 #include "distributions/normal.hh"
-#include "util_math.hh"
 
 #include <boost/math/distributions/inverse_gamma.hpp>
 #include <boost/math/distributions/normal.hpp>
 #include <boost/test/included/unit_test.hpp>
+
+#include "util_math.hh"
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_against_boost) {
@@ -24,7 +25,7 @@ BOOST_AUTO_TEST_CASE(test_against_boost) {
   for (int j = 0; j < num_trials; ++j) {
     double x = 1. / (std::gamma_distribution<double>(nd.v, nd.s))(prng2);
     inverse_gamma_samples.emplace_back(x);
-    double y = (std::normal_distribution<double>(nd.m, sqrt(x / nd.r))) (prng2);
+    double y = (std::normal_distribution<double>(nd.m, sqrt(x / nd.r)))(prng2);
     normal_samples.emplace_back(y);
   }
 
@@ -39,8 +40,8 @@ BOOST_AUTO_TEST_CASE(test_against_boost) {
       double ig = inverse_gamma_samples[j];
       double n = normal_samples[j];
       boost::math::normal_distribution normal_dist(n, sqrt(ig));
-      average_log_prob.emplace_back(
-          log(boost::math::pdf(normal_dist, static_cast<double>(i)) / num_trials));
+      average_log_prob.emplace_back(log(
+          boost::math::pdf(normal_dist, static_cast<double>(i)) / num_trials));
     }
     accumulated_log_prob += logsumexp(average_log_prob);
     BOOST_TEST(nd.logp_score() == accumulated_log_prob, tt::tolerance(0.3));


### PR DESCRIPTION
Added marginal tests, to ensure that Normal and BetaBernoulli were computing the right marginal (comparing against inexact marginalization with boost).

* Fixed DirichletCategorical and Bigram logp_score. `transform_reduce` was using 0 as an accumulator instead of 0., so this was rounding all calculations to ints.

* Checked that DirichletCategorical and BetaBernoulli agree.