### PR TITLE
Fix normal distribution and replace MC tests with Quadrature tests.

### DIFF
--- a/cxx/distributions/adapter.hh
+++ b/cxx/distributions/adapter.hh
@@ -12,7 +12,7 @@
 #include "distributions/base.hh"
 
 template <typename SampleType = double>
-class DistributionAdapter : Distribution<std::string> {
+class DistributionAdapter : public Distribution<std::string> {
  public:
   // The underlying distribution that is being adapted.  We own the
   // underlying Distribution.
@@ -34,11 +34,13 @@ class DistributionAdapter : Distribution<std::string> {
 
   void incorporate(const std::string& x) {
     SampleType s = from_string(x);
+    ++N;
     d->incorporate(s);
   }
 
   void unincorporate(const std::string& x) {
     SampleType s = from_string(x);
+    --N;
     d->unincorporate(s);
   }
 

--- a/cxx/distributions/adapter_test.cc
+++ b/cxx/distributions/adapter_test.cc
@@ -12,16 +12,22 @@ namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(adapt_normal) {
   std::mt19937 prng;
-  DistributionAdapter<double> ad(new Normal(&prng));
+  Normal* n = new Normal(&prng);
+  DistributionAdapter<double> ad(n);
 
   ad.incorporate("5.0");
   ad.incorporate("-2.0");
+  BOOST_TEST(n->N == 2);
+
   ad.unincorporate("5.0");
   ad.incorporate("7.0");
-  ad.unincorporate("-2.0");
+  BOOST_TEST(n->N == 2);
 
-  BOOST_TEST(ad.logp("6.0") == -2.7673076255063034, tt::tolerance(1e-6));
-  BOOST_TEST(ad.logp_score() == -4.7299819282937534, tt::tolerance(1e-6));
+  ad.unincorporate("-2.0");
+  BOOST_TEST(n->N == 1);
+
+  BOOST_TEST(ad.logp("6.0") == n->logp(6.), tt::tolerance(1e-6));
+  BOOST_TEST(ad.logp_score() == n->logp_score(), tt::tolerance(1e-6));
 
   std::string samp = ad.sample();
 }

--- a/cxx/distributions/adapter_test.cc
+++ b/cxx/distributions/adapter_test.cc
@@ -17,14 +17,14 @@ BOOST_AUTO_TEST_CASE(adapt_normal) {
 
   ad.incorporate("5.0");
   ad.incorporate("-2.0");
-  BOOST_TEST(n->N == 2);
+  BOOST_TEST(n->N == ad.N);
 
   ad.unincorporate("5.0");
   ad.incorporate("7.0");
-  BOOST_TEST(n->N == 2);
+  BOOST_TEST(n->N == ad.N);
 
   ad.unincorporate("-2.0");
-  BOOST_TEST(n->N == 1);
+  BOOST_TEST(n->N == ad.N);
 
   BOOST_TEST(ad.logp("6.0") == n->logp(6.), tt::tolerance(1e-6));
   BOOST_TEST(ad.logp_score() == n->logp_score(), tt::tolerance(1e-6));

--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -6,9 +6,11 @@
 
 #include <boost/math/distributions/bernoulli.hpp>
 #include <boost/math/distributions/beta.hpp>
+#include <boost/math/quadrature/gauss_kronrod.hpp>
 #include <boost/test/included/unit_test.hpp>
 
 #include "util_math.hh"
+namespace bm = boost::math;
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
@@ -35,35 +37,26 @@ BOOST_AUTO_TEST_CASE(test_simple) {
 }
 
 BOOST_AUTO_TEST_CASE(test_against_boost) {
-  // Construct a biased estimator of the log_prob using Boost, and check that we
-  // are within tolerance.
   std::mt19937 prng;
   std::mt19937 prng2;
   BetaBernoulli bb(&prng);
-  const int num_trials = 5000;
 
-  std::vector<double> beta_samples;
-  for (int j = 0; j < num_trials; ++j) {
-    double x = (std::gamma_distribution<double>(bb.alpha, 1.))(prng2);
-    double y = (std::gamma_distribution<double>(bb.beta, 1.))(prng2);
-    beta_samples.emplace_back(x / (x + y));
-  }
-
-  double accumulated_log_prob;
-  boost::math::beta_distribution<> beta_dist(bb.alpha, bb.beta);
+  bm::beta_distribution<> beta_dist(bb.alpha, bb.beta);
 
   for (int i = 0; i < 10; ++i) {
-    bb.incorporate(i % 2);
-    std::vector<double> average_log_prob;
+    bb.incorporate(static_cast<double>(i % 2));
 
-    for (double b : beta_samples) {
-      boost::math::bernoulli_distribution bernoulli_dist(b);
-      average_log_prob.emplace_back(
-          log(boost::math::pdf(bernoulli_dist, static_cast<double>(i % 2)) /
-              num_trials));
-    }
-    accumulated_log_prob += logsumexp(average_log_prob);
-    BOOST_TEST(bb.logp_score() == accumulated_log_prob, tt::tolerance(0.3));
+    auto integrand = [&beta_dist, &i](double t) {
+      bm::bernoulli_distribution bernoulli_dist(t);
+      double result = bm::pdf(beta_dist, t);
+      for (int j = 0; j <= i; ++j) {
+        result *= bm::pdf(bernoulli_dist, static_cast<double>(j % 2));
+      }
+      return result;
+    };
+    double result = bm::quadrature::gauss_kronrod<double, 100>::integrate(
+        integrand, 0., 1.);
+    BOOST_TEST(bb.logp_score() == log(result), tt::tolerance(1e-5));
   }
 }
 

--- a/cxx/distributions/normal.hh
+++ b/cxx/distributions/normal.hh
@@ -57,7 +57,7 @@ class Normal : public Distribution<double> {
     ++N;
     double old_mean = mean;
     mean += (x - mean) / N;
-    var += (x - mean) * (x - old_mean);
+    var += ((x - mean) * (x - old_mean) - var) / N;
   }
 
   void unincorporate(const double& x) {
@@ -70,7 +70,7 @@ class Normal : public Distribution<double> {
     }
     double old_mean = mean;
     mean = (mean * old_N - x) / N;
-    var -= (x - mean) * (x - old_mean);
+    var = (var * old_N - (x - mean) * (x - old_mean)) / N;
   }
 
   void posterior_hypers(double* mprime, double* sprime) const {
@@ -80,7 +80,7 @@ class Normal : public Distribution<double> {
     // s' = s + C + r m^2 - r' m' m'
     double mdelta = r * (m - mean) / (r + N);
     *mprime = mean + mdelta;
-    *sprime = s + r * (m * m - *mprime * *mprime) +
+    *sprime = s + r * (m - *mprime) * (m + *mprime) +
               N * (var - 2 * mean * mdelta - mdelta * mdelta);
   }
 

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -6,45 +6,65 @@
 
 #include <boost/math/distributions/inverse_gamma.hpp>
 #include <boost/math/distributions/normal.hpp>
+#include <boost/math/quadrature/gauss_kronrod.hpp>
 #include <boost/test/included/unit_test.hpp>
 
 #include "util_math.hh"
+namespace bm = boost::math;
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE(test_against_boost) {
-  // Construct a biased estimator of the log_prob using Boost, and check that we
-  // are within tolerance.
+BOOST_AUTO_TEST_CASE(test_welford) {
   std::mt19937 prng;
-  std::mt19937 prng2;
   Normal nd(&prng);
-
-  std::vector<double> inverse_gamma_samples;
-  std::vector<double> normal_samples;
-  int num_trials = 5000;
-
-  for (int j = 0; j < num_trials; ++j) {
-    double x = 1. / (std::gamma_distribution<double>(nd.v, nd.s))(prng2);
-    inverse_gamma_samples.emplace_back(x);
-    double y = (std::normal_distribution<double>(nd.m, sqrt(x / nd.r)))(prng2);
-    normal_samples.emplace_back(y);
+  std::vector<double> entries{-1., 2., 4., 5., 6., 20.};
+  std::vector<double> expected_means{-1., 0.5, 1 + 2 / 3., 2.5, 3.2, 6.};
+  std::vector<double> expected_vars{0.,   2.25, 4 + 2 / 9.,
+                                    5.25, 6.16, 44. + 1 / 3.};
+  for (int i = 0; i < std::ssize(entries); ++i) {
+    nd.incorporate(entries[i]);
+    BOOST_TEST(nd.mean == expected_means[i], tt::tolerance(1e-6));
+    BOOST_TEST(nd.var == expected_vars[i], tt::tolerance(1e-6));
   }
 
-  double accumulated_log_prob;
-  boost::math::inverse_gamma_distribution<> inv_gamma_dist(nd.v, nd.s);
+  for (int i = std::ssize(entries) - 1; i > 0; --i) {
+    nd.unincorporate(entries[i]);
+    BOOST_TEST(nd.mean == expected_means[i - 1], tt::tolerance(1e-6));
+    BOOST_TEST(nd.var == expected_vars[i - 1], tt::tolerance(1e-6));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_against_boost) {
+  std::mt19937 prng;
+  Normal nd(&prng);
+
+  bm::inverse_gamma_distribution inv_gamma_dist(nd.v / 2., nd.s / 2.);
 
   for (int i = 0; i < 10; ++i) {
     nd.incorporate(i);
-    std::vector<double> average_log_prob;
+    std::cerr << nd.logp_score() << "\n";
 
-    for (int j = 0; j < num_trials; ++j) {
-      double ig = inverse_gamma_samples[j];
-      double n = normal_samples[j];
-      boost::math::normal_distribution normal_dist(n, sqrt(ig));
-      average_log_prob.emplace_back(log(
-          boost::math::pdf(normal_dist, static_cast<double>(i)) / num_trials));
-    }
-    accumulated_log_prob += logsumexp(average_log_prob);
-    BOOST_TEST(nd.logp_score() == accumulated_log_prob, tt::tolerance(0.3));
+    auto integrand1 = [&nd, &inv_gamma_dist, &i](double n, double ig) {
+      bm::normal_distribution normal_prior_dist(nd.m, sqrt(ig / nd.r));
+      bm::normal_distribution normal_dist(n, sqrt(ig));
+      double result =
+          bm::pdf(normal_prior_dist, n) * bm::pdf(inv_gamma_dist, ig);
+      for (int j = 0; j <= i; ++j) {
+        result *= bm::pdf(normal_dist, j);
+      }
+      return result;
+    };
+
+    auto integrand2 = [&integrand1](double ig) {
+      auto f = [&](double n) { return integrand1(n, ig); };
+      return bm::quadrature::gauss_kronrod<double, 100>::integrate(
+          f, -std::numeric_limits<double>::infinity(),
+          std::numeric_limits<double>::infinity());
+    };
+
+    double result = bm::quadrature::gauss_kronrod<double, 100>::integrate(
+        integrand2, 0., std::numeric_limits<double>::infinity());
+
+    BOOST_TEST(nd.logp_score() == log(result), tt::tolerance(1e-4));
   }
   BOOST_TEST(nd.N == 10);
 }
@@ -63,9 +83,6 @@ BOOST_AUTO_TEST_CASE(simple) {
 
   nd.unincorporate(-2.0);
   BOOST_TEST(nd.N == 1);
-
-  BOOST_TEST(nd.logp(6.0) == -2.7673076255063034, tt::tolerance(1e-6));
-  BOOST_TEST(nd.logp_score() == -4.7299819282937534, tt::tolerance(1e-6));
 }
 
 BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -41,7 +41,6 @@ BOOST_AUTO_TEST_CASE(test_against_boost) {
 
   for (int i = 0; i < 10; ++i) {
     nd.incorporate(i);
-    std::cerr << nd.logp_score() << "\n";
 
     auto integrand1 = [&nd, &inv_gamma_dist, &i](double n, double ig) {
       bm::normal_distribution normal_prior_dist(nd.m, sqrt(ig / nd.r));


### PR DESCRIPTION
* The quadrature tests lower the the error substantially for beta Bernoulli and Normal.
* Fixed two bugs in normal: Welford's algorithm wasn't accurately calculating the mean and variance (for incorporate / unincorporated) and replaced a difference of squares with a product (for numerical stability)
* Changed adapter to test that it produces the same result as the inner distribution (since that's what we actually care about).