### PR TITLE
Support different observation types in util_io.

### DIFF
--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
   auto schema = load_schema(path_schema);
 
   std::cout << "loading observations from " << path_obs << std::endl;
-  auto observations = load_observations(path_obs);
+  auto observations = load_observations(path_obs, schema);
   auto encoding = encode_observations(schema, observations);
 
   if (mode == "irm") {

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -201,6 +201,8 @@ class Relation {
  public:
   using ValueType = typename DistributionType::SampleType;
   using DType = DistributionType;
+  static_assert(std::is_base_of<Distribution<ValueType>, DType>::value, 
+                "DistributionType must inherit from Distribution.");
   // human-readable name
   const std::string name;
   // Distribution over the relation's codomain.
@@ -544,7 +546,7 @@ class Relation {
 
 using RelationVariant =
     std::variant<Relation<BetaBernoulli>*, Relation<Bigram>*,
-                 // Relation<double, DirichletCategorical>*,
+                 // Relation<DirichletCategorical>*,
                  Relation<Normal>*>;
 
 class IRM {

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -847,7 +847,8 @@ class HIRM {
     }
   }
 
-  void incorporate(const std::string& r, const T_items& items, double value) {
+  void incorporate(const std::string& r, const T_items& items, 
+                   const ObservationVariant& value) {
     IRM* irm = relation_to_irm(r);
     irm->incorporate(r, items, value);
   }

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
   printf("== HIRM == \n");
   auto schema_unary = load_schema(path_schema);
   printf("--- loaded schema --- \n");
-  auto observations_unary = load_observations(path_obs);
+  auto observations_unary = load_observations(path_obs, schema_unary);
   printf("--- loaded observations --- \n");
   auto encoding_unary = encode_observations(schema_unary, observations_unary);
   printf("--- encoded observations --- \n");

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
 
   std::string path_obs = path_base + ".obs";
   std::cout << "loading observations from " << path_obs << std::endl;
-  auto observations = load_observations(path_obs);
+  auto observations = load_observations(path_obs, schema);
   T_encoding encoding = encode_observations(schema, observations);
 
   IRM irm(schema, &prng);

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
   }
 
   IRM irm3(schema, &prng);
-  auto observations = load_observations("assets/animals.binary.obs");
+  auto observations = load_observations("assets/animals.binary.obs", schema);
   auto encoding = encode_observations(schema, observations);
   auto item_to_code = std::get<0>(encoding);
   for (auto const& i : observations) {
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
     auto value = std::get<2>(i);
     auto item = std::get<1>(i);
     printf("incorporating %s ", relation.c_str());
-    printf("%1.f ", value);
+    printf("%1.f ", std::get<double>(value));
     int counter = 0;
     T_items items_code;
     for (auto const& item : std::get<1>(i)) {

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -40,8 +40,13 @@ ObservationVariant observation_string_to_value(const std::string& value_str,
                                                const std::string& distribution) {
   if (distribution == "normal" || distribution == "bernoulli") {
     return std::stod(value_str);
-  } else {
+  } else if (distribution == "categorical") {
+    return std::stoi(value_str);
+  } else if (distribution == "bigram") {
     return value_str;
+  } else {
+    // Unrecognized distribution name.
+    assert(false);
   }
 }
 

--- a/cxx/util_io.hh
+++ b/cxx/util_io.hh
@@ -9,7 +9,7 @@ typedef std::map<std::string, std::map<std::string, T_item>> T_encoding_f;
 typedef std::map<std::string, std::map<T_item, std::string>> T_encoding_r;
 typedef std::tuple<T_encoding_f, T_encoding_r> T_encoding;
 
-typedef std::tuple<std::string, std::vector<std::string>, double> T_observation;
+typedef std::tuple<std::string, std::vector<std::string>, ObservationVariant> T_observation;
 typedef std::vector<T_observation> T_observations;
 
 typedef std::unordered_map<std::string, T_item> T_assignment;
@@ -17,7 +17,7 @@ typedef std::unordered_map<std::string, T_assignment> T_assignments;
 
 // disk IO
 T_schema load_schema(const std::string& path);
-T_observations load_observations(const std::string& path);
+T_observations load_observations(const std::string& path, const T_schema& schema);
 T_encoding encode_observations(const T_schema& schema,
                                const T_observations& observations);
 


### PR DESCRIPTION
This allows for different types of observations to be read in, depending on distribution type. Only Bernoulli-distributed data is currently tested, in the integration tests (at some point, when the model is further along, we should add more complex integration tests involving different data models. We should also unit test util_io, though I wouldn't put that at highest priority now.)