### PR TITLE
Change DirichletCategorical SampleType from double to int.

### DIFF
--- a/cxx/distributions/dirichlet_categorical.cc
+++ b/cxx/distributions/dirichlet_categorical.cc
@@ -9,13 +9,13 @@
 
 #include "util_math.hh"
 
-void DirichletCategorical::incorporate(const double& x) {
-  assert(x >= 0 && x < counts.size());
+void DirichletCategorical::incorporate(const int& x) {
+  assert(x >= 0 && x < std::ssize(counts));
   counts[size_t(x)] += 1;
   ++N;
 }
 
-void DirichletCategorical::unincorporate(const double& x) {
+void DirichletCategorical::unincorporate(const int& x) {
   const size_t y = x;
   assert(y < counts.size());
   counts[y] -= 1;
@@ -24,8 +24,8 @@ void DirichletCategorical::unincorporate(const double& x) {
   assert(0 <= N);
 }
 
-double DirichletCategorical::logp(const double& x) const {
-  assert(x >= 0 && x < counts.size());
+double DirichletCategorical::logp(const int& x) const {
+  assert(x >= 0 && x < std::ssize(counts));
   const double numer = log(alpha + counts[size_t(x)]);
   const double denom = log(N + alpha * counts.size());
   return numer - denom;
@@ -40,12 +40,12 @@ double DirichletCategorical::logp_score() const {
   }
   return lgamma(a) - lgamma(a + N) + lg - k * lgamma(alpha);
 }
-double DirichletCategorical::sample() {
+
+int DirichletCategorical::sample() {
   std::vector<double> weights(counts.size());
   std::transform(counts.begin(), counts.end(), weights.begin(),
                  [&](size_t y) -> double { return y + alpha; });
-  int idx = choice(weights, prng);
-  return double(idx);
+  return choice(weights, prng);
 }
 
 void DirichletCategorical::transition_hyperparameters() {

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -10,7 +10,7 @@
 #define ALPHA_GRID \
   { 1e-4, 1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0, 1000.0, 10000.0 }
 
-class DirichletCategorical : public Distribution<double> {
+class DirichletCategorical : public Distribution<int> {
  public:
   double alpha = 1;         // hyperparameter (applies to all categories)
   std::vector<int> counts;  // counts of observed categories
@@ -22,15 +22,15 @@ class DirichletCategorical : public Distribution<double> {
     this->prng = prng;
     counts = std::vector<int>(k, 0);
   }
-  void incorporate(const double& x);
+  void incorporate(const int& x);
 
-  void unincorporate(const double& x);
+  void unincorporate(const int& x);
 
-  double logp(const double& x) const;
+  double logp(const int& x) const;
 
   double logp_score() const;
 
-  double sample();
+  int sample();
 
   void transition_hyperparameters();
 };


### PR DESCRIPTION
The tests etc. already assumed these were ints, which were being implicitly cast to double.

I'm happy to do BetaBernoulli double->bool while I'm at it too, unless you prefer to, just let me know.