### PR TITLE
Plumb prng through as an arg where needed instead of making it a clas…

### DIFF
--- a/cxx/distributions/base.hh
+++ b/cxx/distributions/base.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include<random>
 
 template <typename T>
 class Distribution {
@@ -30,14 +31,12 @@ class Distribution {
   virtual double logp_score() const = 0;
 
   // A sample from the predictive distribution.
-  // TODO(thomaswc): Consider refactoring so that this takes a
-  // PRNG parameter.
-  virtual T sample() = 0;
+  virtual T sample(std::mt19937* prng) = 0;
 
   // Transition the hyperparameters.  The probability of transitioning to
   // a particular set of hyperparameters should be proportional to
   // e^logp_score() under those hyperparameters.
-  virtual void transition_hyperparameters() = 0;
+  virtual void transition_hyperparameters(std::mt19937* prng) = 0;
 
   virtual ~Distribution() = default;
 };

--- a/cxx/distributions/beta_bernoulli.cc
+++ b/cxx/distributions/beta_bernoulli.cc
@@ -34,7 +34,7 @@ double BetaBernoulli::logp_score() const {
   return v1 - v2;
 }
 
-bool BetaBernoulli::sample() {
+bool BetaBernoulli::sample(std::mt19937* prng) {
   double p = exp(logp(1));
   std::vector<bool> items{false, true};
   std::vector<double> weights{1 - p, p};
@@ -42,7 +42,7 @@ bool BetaBernoulli::sample() {
   return items[idx];
 }
 
-void BetaBernoulli::transition_hyperparameters() {
+void BetaBernoulli::transition_hyperparameters(std::mt19937* prng) {
   std::vector<double> logps;
   std::vector<std::pair<double, double>> hypers;
   // C++ doesn't yet allow range for-loops over existing variables.  Sigh.

--- a/cxx/distributions/beta_bernoulli.hh
+++ b/cxx/distributions/beta_bernoulli.hh
@@ -7,21 +7,16 @@
 #include "distributions/base.hh"
 #include "util_math.hh"
 
-// TODO(thomaswc, emilyaf): Change BetaBernoulli to use bool instead of
-// double.
 class BetaBernoulli : public Distribution<bool> {
  public:
   double alpha = 1;  // hyperparameter
   double beta = 1;   // hyperparameter
   int s = 0;         // sum of observed values
-  std::mt19937* prng;
 
   std::vector<double> alpha_grid;
   std::vector<double> beta_grid;
 
-  // BetaBernoulli does not take ownership of prng.
-  BetaBernoulli(std::mt19937* prng) {
-    this->prng = prng;
+  BetaBernoulli() {
     alpha_grid = log_linspace(1e-4, 1e4, 10, true);
     beta_grid = log_linspace(1e-4, 1e4, 10, true);
   }
@@ -34,7 +29,7 @@ class BetaBernoulli : public Distribution<bool> {
 
   double logp_score() const;
 
-  bool sample();
+  bool sample(std::mt19937* prng);
 
-  void transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng);
 };

--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -15,8 +15,7 @@ namespace tt = boost::test_tools;
 namespace bm = boost::math;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
-  std::mt19937 prng;
-  BetaBernoulli bb(&prng);
+  BetaBernoulli bb;
 
   bb.incorporate(1);
   bb.incorporate(0);
@@ -38,8 +37,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_prob) {
-  std::mt19937 prng;
-  BetaBernoulli bb(&prng);
+  BetaBernoulli bb;
 
   bm::beta_distribution<> beta_dist(bb.alpha, bb.beta);
 
@@ -61,8 +59,7 @@ BOOST_AUTO_TEST_CASE(test_log_prob) {
 }
 
 BOOST_AUTO_TEST_CASE(test_posterior_predictive) {
-  std::mt19937 prng;
-  BetaBernoulli bb(&prng);
+  BetaBernoulli bb;
 
   bm::beta_distribution<> beta_dist(bb.alpha, bb.beta);
 
@@ -99,9 +96,9 @@ BOOST_AUTO_TEST_CASE(test_posterior_predictive) {
 
 BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   std::mt19937 prng;
-  BetaBernoulli bb(&prng);
+  BetaBernoulli bb;
 
-  bb.transition_hyperparameters();
+  bb.transition_hyperparameters(&prng);
 
   bb.incorporate(0);
   for (int i = 0; i < 100; ++i) {
@@ -109,7 +106,7 @@ BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   }
 
   BOOST_TEST(bb.N == 101);
-  bb.transition_hyperparameters();
+  bb.transition_hyperparameters(&prng);
   // Expect that since we saw a lot of 1's, that alpha will be much larger than
   // beta.
   BOOST_TEST(bb.alpha > bb.beta);

--- a/cxx/distributions/bigram.cc
+++ b/cxx/distributions/bigram.cc
@@ -72,14 +72,14 @@ double Bigram::logp_score() const {
   return logp;
 }
 
-std::string Bigram::sample() {
+std::string Bigram::sample(std::mt19937* prng) {
   std::string sampled_string;
   // TODO(emilyaf): Reconsider the reserved length and maybe enforce a
   // max length.
   sampled_string.reserve(30);
   // Sample the first character conditioned on the stop/start symbol.
   size_t current_ind = num_chars;
-  size_t next_ind = transition_dists[current_ind].sample();
+  size_t next_ind = transition_dists[current_ind].sample(prng);
   transition_dists[current_ind].incorporate(next_ind);
   current_ind = next_ind;
 
@@ -88,7 +88,7 @@ std::string Bigram::sample() {
   // subsequent samples are conditioned on its observation.
   while (current_ind != num_chars) {
     sampled_string += index_to_char(current_ind);
-    next_ind = transition_dists[current_ind].sample();
+    next_ind = transition_dists[current_ind].sample(prng);
     transition_dists[current_ind].incorporate(next_ind);
     current_ind = next_ind;
   }
@@ -103,7 +103,7 @@ void Bigram::set_alpha(double alphat) {
   }
 }
 
-void Bigram::transition_hyperparameters() {
+void Bigram::transition_hyperparameters(std::mt19937* prng) {
   std::vector<double> logps;
   std::vector<double> alphas;
   // C++ doesn't yet allow range for-loops over existing variables.  Sigh.

--- a/cxx/distributions/bigram.hh
+++ b/cxx/distributions/bigram.hh
@@ -20,17 +20,14 @@ class Bigram : public Distribution<std::string> {
   double alpha = 1;  // hyperparameter for all transition distributions.
   size_t num_chars = '~' - ' ' + 1;  // printable ASCII without DEL.
   mutable std::vector<DirichletCategorical> transition_dists;
-  std::mt19937* prng;
 
-  // Bigram does not take ownership of prng.
-  Bigram(std::mt19937* prng) {
-    this->prng = prng;
+  Bigram() {
     const size_t total_chars = num_chars + 1;  // Include a start/stop symbol.
 
     // The distribution at index `i` represents `p(X_{j+1} | X_j == char_i)`.
     transition_dists.reserve(total_chars);
     for (size_t i = 0; i != total_chars; ++i) {
-      transition_dists.emplace_back(prng, total_chars);
+      transition_dists.emplace_back(total_chars);
     }
   }
 
@@ -42,9 +39,9 @@ class Bigram : public Distribution<std::string> {
 
   double logp_score() const;
 
-  std::string sample();
+  std::string sample(std::mt19937* prng);
 
   void set_alpha(double alphat);
 
-  void transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng);
 };

--- a/cxx/distributions/bigram_test.cc
+++ b/cxx/distributions/bigram_test.cc
@@ -8,8 +8,7 @@
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
-  std::mt19937 prng;
-  Bigram bg(&prng);
+  Bigram bg;
 
   bg.incorporate("hello");
   bg.incorporate("world");
@@ -25,8 +24,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
 }
 
 BOOST_AUTO_TEST_CASE(test_set_alpha) {
-  std::mt19937 prng;
-  Bigram bg(&prng);
+  Bigram bg;
 
   bg.incorporate("hello");
   double first_lp = bg.logp_score();
@@ -41,14 +39,14 @@ BOOST_AUTO_TEST_CASE(test_set_alpha) {
 
 BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   std::mt19937 prng;
-  Bigram bg(&prng);
+  Bigram bg;
 
-  bg.transition_hyperparameters();
+  bg.transition_hyperparameters(&prng);
   for (int i = 0; i < 100; ++i) {
     bg.incorporate("abcdefghijklmnopqrstuvwxyz");
   }
 
-  bg.transition_hyperparameters();
+  bg.transition_hyperparameters(&prng);
 
   BOOST_TEST(bg.alpha < 1.0);
 }

--- a/cxx/distributions/crp.cc
+++ b/cxx/distributions/crp.cc
@@ -31,7 +31,7 @@ void CRP::unincorporate(const T_item& item) {
   --N;
 }
 
-int CRP::sample() {
+int CRP::sample(std::mt19937* prng) {
   auto crp_dist = tables_weights();
   std::vector<int> items(crp_dist.size());
   std::vector<double> weights(crp_dist.size());
@@ -98,7 +98,7 @@ std::unordered_map<int, double> CRP::tables_weights_gibbs(int table) const {
   return dist;
 }
 
-void CRP::transition_alpha() {
+void CRP::transition_alpha(std::mt19937* prng) {
   if (N == 0) {
     return;
   }

--- a/cxx/distributions/crp.hh
+++ b/cxx/distributions/crp.hh
@@ -16,15 +16,14 @@ class CRP {
   std::unordered_map<int, std::unordered_set<T_item>>
       tables;  // map from table id to set of customers
   std::unordered_map<T_item, int> assignments;  // map from customer to table id
-  std::mt19937* prng;
 
-  CRP(std::mt19937* prng) { this->prng = prng; }
+  CRP() {}
 
   void incorporate(const T_item& item, int table);
 
   void unincorporate(const T_item& item);
 
-  int sample();
+  int sample(std::mt19937* prng);
 
   double logp(int table) const;
 
@@ -34,5 +33,5 @@ class CRP {
 
   std::unordered_map<int, double> tables_weights_gibbs(int table) const;
 
-  void transition_alpha();
+  void transition_alpha(std::mt19937* prng);
 };

--- a/cxx/distributions/crp_test.cc
+++ b/cxx/distributions/crp_test.cc
@@ -14,8 +14,7 @@ namespace tt = boost::test_tools;
 namespace bm = boost::math;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
-  std::mt19937 prng;
-  CRP crp(&prng);
+  CRP crp;
 
   T_item cat = 1;
   T_item dog = 2;
@@ -86,8 +85,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_prob) {
-  std::mt19937 prng;
-  CRP crp(&prng);
+  CRP crp;
 
   T_item desk = 1;
   T_item chair = 2;
@@ -125,23 +123,23 @@ BOOST_AUTO_TEST_CASE(test_log_prob) {
 
 BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   std::mt19937 prng;
-  CRP crp(&prng);
+  CRP crp;
 
-  crp.transition_alpha();
+  crp.transition_alpha(&prng);
   double old_alpha = crp.alpha;
 
   for (int i = 0; i < 100; ++i) {
     crp.incorporate(i, 0);
   }
 
-  crp.transition_alpha();
+  crp.transition_alpha(&prng);
   // Expect that since all items are at one table, the new alpha is low.
   BOOST_TEST(crp.alpha < old_alpha);
 }
 
 BOOST_AUTO_TEST_CASE(test_crp_sample) {
   std::mt19937 prng;
-  auto crp = CRP(&prng);
+  CRP crp;
   for (int i = 0; i < 10; ++i) {
     crp.incorporate(i, 0);
   }
@@ -156,7 +154,7 @@ BOOST_AUTO_TEST_CASE(test_crp_sample) {
   std::map<int, int> table_count;
   const int num_draws = 3000;
   for (int i = 0; i < num_draws; ++i) {
-    ++table_count[crp.sample()];
+    ++table_count[crp.sample(&prng)];
   }
 
   // Check that the count of 0's is close to 10/16 = 5/8.

--- a/cxx/distributions/dirichlet_categorical.cc
+++ b/cxx/distributions/dirichlet_categorical.cc
@@ -41,14 +41,14 @@ double DirichletCategorical::logp_score() const {
   return lgamma(a) - lgamma(a + N) + lg - k * lgamma(alpha);
 }
 
-int DirichletCategorical::sample() {
+int DirichletCategorical::sample(std::mt19937* prng) {
   std::vector<double> weights(counts.size());
   std::transform(counts.begin(), counts.end(), weights.begin(),
                  [&](size_t y) -> double { return y + alpha; });
   return choice(weights, prng);
 }
 
-void DirichletCategorical::transition_hyperparameters() {
+void DirichletCategorical::transition_hyperparameters(std::mt19937* prng) {
   std::vector<double> logps;
   std::vector<double> alphas;
   // C++ doesn't yet allow range for-loops over existing variables.  Sigh.

--- a/cxx/distributions/dirichlet_categorical.hh
+++ b/cxx/distributions/dirichlet_categorical.hh
@@ -14,12 +14,8 @@ class DirichletCategorical : public Distribution<int> {
  public:
   double alpha = 1;         // hyperparameter (applies to all categories)
   std::vector<int> counts;  // counts of observed categories
-  std::mt19937* prng;
 
-  // DirichletCategorical does not take ownership of prng.
-  DirichletCategorical(std::mt19937* prng,
-                       int k) {  // k is number of categories
-    this->prng = prng;
+  DirichletCategorical(int k) {  // k is number of categories
     counts = std::vector<int>(k, 0);
   }
   void incorporate(const int& x);
@@ -30,7 +26,7 @@ class DirichletCategorical : public Distribution<int> {
 
   double logp_score() const;
 
-  int sample();
+  int sample(std::mt19937* prng);
 
-  void transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng);
 };

--- a/cxx/distributions/dirichlet_categorical_test.cc
+++ b/cxx/distributions/dirichlet_categorical_test.cc
@@ -10,10 +10,9 @@
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_matches_beta_bernoulli) {
-  std::mt19937 prng;
   // 2-category Dirichlet Categorical is the same as a BetaBernoulli.
-  DirichletCategorical dc(&prng, 2);
-  BetaBernoulli bb(&prng);
+  DirichletCategorical dc(2);
+  BetaBernoulli bb;
 
   for (int i = 0; i < 10; ++i) {
     dc.incorporate(i % 2);
@@ -35,9 +34,8 @@ BOOST_AUTO_TEST_CASE(test_logp_score) {
   // Sample from a Dirichlet and use that to create a MC estimate of the log
   // prob.
   std::mt19937 prng;
-  std::mt19937 prng2;
 
-  DirichletCategorical dc(&prng, 5);
+  DirichletCategorical dc(5);
 
   int num_samples = 1000;
   std::vector<std::vector<double>> dirichlet_samples;
@@ -45,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_logp_score) {
   for (int i = 0; i < num_samples; ++i) {
     std::vector<double> sample;
     for (int j = 0; j < 5; ++j) {
-      sample.emplace_back(gamma_dist(prng2));
+      sample.emplace_back(gamma_dist(prng));
     }
     double sum_of_elements = std::accumulate(sample.begin(), sample.end(), 0.);
     for (int j = 0; j < 5; ++j) {
@@ -73,10 +71,9 @@ BOOST_AUTO_TEST_CASE(test_logp) {
   // Sample from a Dirichlet and use that to create a MC estimate of the log
   // prob.
   std::mt19937 prng;
-  std::mt19937 prng2;
   int num_categories = 5;
 
-  DirichletCategorical dc(&prng, num_categories);
+  DirichletCategorical dc(num_categories);
 
   // We'll use the fact that the posterior distribution of a
   // DirichletCategorical is a Dirichlet.
@@ -105,7 +102,7 @@ BOOST_AUTO_TEST_CASE(test_logp) {
     for (int j = 0; j < num_samples; ++j) {
       std::vector<double> sample;
       for (int k = 0; k < num_categories; ++k) {
-        sample.emplace_back(gamma_dists[k](prng2));
+        sample.emplace_back(gamma_dists[k](prng));
       }
       double sum_of_elements =
           std::accumulate(sample.begin(), sample.end(), 0.);
@@ -123,15 +120,15 @@ BOOST_AUTO_TEST_CASE(test_logp) {
 
 BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   std::mt19937 prng;
-  DirichletCategorical dc(&prng, 10);
+  DirichletCategorical dc(10);
 
-  dc.transition_hyperparameters();
+  dc.transition_hyperparameters(&prng);
 
   for (int i = 0; i < 100; ++i) {
     dc.incorporate(i % 10);
   }
 
   BOOST_TEST(dc.N == 100);
-  dc.transition_hyperparameters();
+  dc.transition_hyperparameters(&prng);
   BOOST_TEST(dc.alpha > 1.0);
 }

--- a/cxx/distributions/normal.cc
+++ b/cxx/distributions/normal.cc
@@ -63,7 +63,7 @@ double Normal::logp_score() const {
   return -0.5 * N * log(M_2PI) + logZ(r + N, v + N, sprime) - logZ(r, v, s);
 }
 
-double Normal::sample() {
+double Normal::sample(std::mt19937* prng) {
   double rn = r + N;
   double nu = v + N;
   double mprime, sprime;
@@ -78,7 +78,7 @@ double Normal::sample() {
   return d(*prng);
 }
 
-void Normal::transition_hyperparameters() {
+void Normal::transition_hyperparameters(std::mt19937* prng) {
   std::vector<double> logps;
   std::vector<std::tuple<double, double, double, double>> hypers;
   for (double rt : R_GRID) {

--- a/cxx/distributions/normal.hh
+++ b/cxx/distributions/normal.hh
@@ -41,10 +41,7 @@ class Normal : public Distribution<double> {
   double mean = 0.0;  // Mean of observed values
   double var = 0.0;   // Variance of observed values
 
-  std::mt19937* prng;
-
-  // Normal does not take ownership of prng.
-  Normal(std::mt19937* prng) { this->prng = prng; }
+  Normal() {}
 
   void incorporate(const double& x);
 
@@ -56,9 +53,9 @@ class Normal : public Distribution<double> {
 
   double logp_score() const;
 
-  double sample();
+  double sample(std::mt19937* prng);
 
-  void transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng);
 
   // Disable copying.
   Normal& operator=(const Normal&) = delete;

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -14,8 +14,7 @@ namespace bm = boost::math;
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_welford) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
   std::vector<double> entries{-1., 2., 4., 5., 6., 20.};
   std::vector<double> expected_means{-1., 0.5, 1 + 2 / 3., 2.5, 3.2, 6.};
   std::vector<double> expected_vars{0.,   2.25, 4 + 2 / 9.,
@@ -34,8 +33,7 @@ BOOST_AUTO_TEST_CASE(test_welford) {
 }
 
 BOOST_AUTO_TEST_CASE(test_log_prob) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   bm::inverse_gamma_distribution inv_gamma_dist(nd.v / 2., nd.s / 2.);
   auto quad = bm::quadrature::gauss_kronrod<double, 100>();
@@ -69,8 +67,7 @@ BOOST_AUTO_TEST_CASE(test_log_prob) {
 }
 
 BOOST_AUTO_TEST_CASE(test_posterior_pred) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   bm::inverse_gamma_distribution inv_gamma_dist(nd.v / 2., nd.s / 2.);
   auto quad = bm::quadrature::gauss<double, 100>();
@@ -114,8 +111,7 @@ BOOST_AUTO_TEST_CASE(test_posterior_pred) {
 }
 
 BOOST_AUTO_TEST_CASE(simple) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   nd.incorporate(5.0);
   nd.incorporate(-2.0);
@@ -130,8 +126,7 @@ BOOST_AUTO_TEST_CASE(simple) {
 }
 
 BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   nd.incorporate(10.0);
   nd.unincorporate(10.0);
@@ -142,8 +137,7 @@ BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {
 }
 
 BOOST_AUTO_TEST_CASE(logp_before_incorporate) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   BOOST_TEST(nd.logp(6.0) == -4.4357424552958129, tt::tolerance(1e-6));
   BOOST_TEST(nd.logp_score() == 0.0, tt::tolerance(1e-6));
@@ -158,21 +152,20 @@ BOOST_AUTO_TEST_CASE(logp_before_incorporate) {
 
 BOOST_AUTO_TEST_CASE(sample) {
   std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   for (int i = 0; i < 1000; ++i) {
     nd.incorporate(42.0);
   }
 
-  double s = nd.sample();
+  double s = nd.sample(&prng);
 
   BOOST_TEST(s > 40.0);
   BOOST_TEST(s < 44.0);
 }
 
 BOOST_AUTO_TEST_CASE(incorporate_raises_logp) {
-  std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
   double old_lp = nd.logp(10.0);
   for (int i = 0; i < 10; ++i) {
@@ -184,8 +177,7 @@ BOOST_AUTO_TEST_CASE(incorporate_raises_logp) {
 }
 
 BOOST_AUTO_TEST_CASE(prior_prefers_origin) {
-  std::mt19937 prng;
-  Normal nd1(&prng), nd2(&prng);
+  Normal nd1, nd2;
 
   for (int i = 0; i < 100; ++i) {
     nd1.incorporate(0.0);
@@ -197,14 +189,14 @@ BOOST_AUTO_TEST_CASE(prior_prefers_origin) {
 
 BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   std::mt19937 prng;
-  Normal nd(&prng);
+  Normal nd;
 
-  nd.transition_hyperparameters();
+  nd.transition_hyperparameters(&prng);
 
   for (int i = 0; i < 100; ++i) {
     nd.incorporate(5.0);
   }
 
-  nd.transition_hyperparameters();
+  nd.transition_hyperparameters(&prng);
   BOOST_TEST(nd.m > 0.0);
 }

--- a/cxx/distributions/zero_mean_normal.hh
+++ b/cxx/distributions/zero_mean_normal.hh
@@ -21,10 +21,7 @@ class ZeroMeanNormal : public Distribution<double> {
   // Sufficient statistics of observed data.
   double var = 0.0;
 
-  std::mt19937* prng;
-
-  // ZeroMeanNormal does not take ownership of prng.
-  ZeroMeanNormal(std::mt19937* prng) { this->prng = prng; }
+  ZeroMeanNormal() {}
 
   void incorporate(const double& x);
 
@@ -36,9 +33,9 @@ class ZeroMeanNormal : public Distribution<double> {
 
   double logp_score() const;
 
-  double sample();
+  double sample(std::mt19937* prng);
 
-  void transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng);
 
   // Disable copying.
   ZeroMeanNormal& operator=(const ZeroMeanNormal&) = delete;

--- a/cxx/distributions/zero_mean_normal_test.cc
+++ b/cxx/distributions/zero_mean_normal_test.cc
@@ -11,8 +11,7 @@ namespace bm = boost::math;
 namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(simple) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
   nd.incorporate(5.0);
   nd.incorporate(-2.0);
@@ -27,8 +26,7 @@ BOOST_AUTO_TEST_CASE(simple) {
 }
 
 BOOST_AUTO_TEST_CASE(test_expected_vars) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
   std::vector<double> entries{-1., 2., 4., 5., 6., 20.};
   std::vector<double> expected_vars{1.0, 2.5, 7.0, 11.5, 16.4, 241.0 / 3.0};
   for (int i = 0; i < std::ssize(entries); ++i) {
@@ -43,8 +41,7 @@ BOOST_AUTO_TEST_CASE(test_expected_vars) {
 }
 
 BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
   nd.incorporate(10.0);
   nd.unincorporate(10.0);
@@ -54,8 +51,7 @@ BOOST_AUTO_TEST_CASE(no_nan_after_incorporate_unincorporate) {
 }
 
 BOOST_AUTO_TEST_CASE(logp_before_incorporate) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
   BOOST_TEST(nd.logp(6.0) == -5.4563792395895785, tt::tolerance(1e-6));
   BOOST_TEST(nd.logp_score() == -0.69314718055994529, tt::tolerance(1e-6));
@@ -70,20 +66,19 @@ BOOST_AUTO_TEST_CASE(logp_before_incorporate) {
 
 BOOST_AUTO_TEST_CASE(sample) {
   std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
   for (int i = 0; i < 1000; ++i) {
     nd.incorporate(42.0);
   }
 
-  double s = nd.sample();
+  double s = nd.sample(&prng);
 
   BOOST_TEST(std::abs(s) < 100.0);
 }
 
 BOOST_AUTO_TEST_CASE(incorporate_raises_logp) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
   double old_lp = nd.logp(10.0);
   for (int i = 0; i < 8; ++i) {
@@ -95,8 +90,7 @@ BOOST_AUTO_TEST_CASE(incorporate_raises_logp) {
 }
 
 BOOST_AUTO_TEST_CASE(prior_prefers_origin) {
-  std::mt19937 prng;
-  ZeroMeanNormal nd1(&prng), nd2(&prng);
+  ZeroMeanNormal nd1, nd2;
 
   for (int i = 0; i < 100; ++i) {
     nd1.incorporate(0.0);
@@ -108,14 +102,14 @@ BOOST_AUTO_TEST_CASE(prior_prefers_origin) {
 
 BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   std::mt19937 prng;
-  ZeroMeanNormal nd(&prng);
+  ZeroMeanNormal nd;
 
-  nd.transition_hyperparameters();
+  nd.transition_hyperparameters(&prng);
 
   for (int i = 0; i < 100; ++i) {
     nd.incorporate(5.0);
   }
 
-  nd.transition_hyperparameters();
+  nd.transition_hyperparameters(&prng);
   BOOST_TEST(nd.beta > 1.0);
 }

--- a/cxx/domain.hh
+++ b/cxx/domain.hh
@@ -15,18 +15,14 @@ class Domain {
   const std::string name;            // human-readable name
   std::unordered_set<T_item> items;  // set of items
   CRP crp;                           // clustering model for items
-  std::mt19937* prng;
 
-  Domain(const std::string& name, std::mt19937* prng) : name(name), crp(prng) {
-    assert(!name.empty());
-    this->prng = prng;
-  }
-  void incorporate(const T_item& item, int table = -1) {
+  Domain(const std::string& name) : name(name), crp() { assert(!name.empty()); }
+  void incorporate(std::mt19937* prng, const T_item& item, int table = -1) {
     if (items.contains(item)) {
       assert(table == -1);
     } else {
       items.insert(item);
-      int t = 0 <= table ? table : crp.sample();
+      int t = 0 <= table ? table : crp.sample(prng);
       crp.incorporate(item, t);
     }
   }

--- a/cxx/domain_test.cc
+++ b/cxx/domain_test.cc
@@ -9,15 +9,15 @@ namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_domain) {
   std::mt19937 prng;
-  Domain d("fruit", &prng);
+  Domain d("fruit");
   std::string relation1 = "grows_on_trees";
   std::string relation2 = "is_same_color";
   T_item banana = 1;
   T_item apple = 2;
-  d.incorporate(banana);
+  d.incorporate(&prng, banana);
   d.set_cluster_assignment_gibbs(banana, 12);
-  d.incorporate(banana);
-  d.incorporate(apple, 5);
+  d.incorporate(&prng, banana);
+  d.incorporate(&prng, apple, 5);
   BOOST_TEST(d.items.contains(banana));
   BOOST_TEST(d.items.contains(apple));
   BOOST_TEST(d.items.size() == 2);
@@ -26,5 +26,4 @@ BOOST_AUTO_TEST_CASE(test_domain) {
   int ca = d.get_cluster_assignment(apple);
   BOOST_TEST(ca == 5);
   BOOST_TEST(cb == 12);
-
 }

--- a/cxx/emissions/base.hh
+++ b/cxx/emissions/base.hh
@@ -8,7 +8,7 @@
 template <typename SampleType = double>
 class Emission : public Distribution<std::pair<SampleType, SampleType>> {
  public:
-  virtual std::pair<SampleType, SampleType> sample() {
+  virtual std::pair<SampleType, SampleType> sample(std::mt19937* prng) {
     assert(false && "sample() should never be called on an Emission\n");
   }
 

--- a/cxx/emissions/bitflip.hh
+++ b/cxx/emissions/bitflip.hh
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <cassert>
+
 #include "emissions/base.hh"
 
 // A *deterministic* Emission class that always emits not(clean).
 // Most users will want to combine this with Sometimes.
 class BitFlip : public Emission<bool> {
  public:
-  BitFlip() {};
+  BitFlip(){};
 
   void incorporate(const std::pair<bool, bool>& x) {
     assert(x.first != x.second);
@@ -24,19 +25,17 @@ class BitFlip : public Emission<bool> {
     return 0.0;
   }
 
-  double logp_score() const {
-    return 0.0;
-  }
+  double logp_score() const { return 0.0; }
 
   // No hyperparameters to transition!
-  void transition_hyperparameters() {}
+  void transition_hyperparameters(std::mt19937* prng) {}
 
   bool sample_corrupted(const bool& clean, std::mt19937* unused_prng) {
     return !clean;
   }
 
   bool propose_clean(const std::vector<bool>& corrupted,
-                           std::mt19937* unused_prng) {
+                     std::mt19937* unused_prng) {
     return !corrupted[0];
   }
 };

--- a/cxx/emissions/bitflip.hh
+++ b/cxx/emissions/bitflip.hh
@@ -8,7 +8,7 @@
 // Most users will want to combine this with Sometimes.
 class BitFlip : public Emission<bool> {
  public:
-  BitFlip(){};
+  BitFlip() {};
 
   void incorporate(const std::pair<bool, bool>& x) {
     assert(x.first != x.second);

--- a/cxx/emissions/bitflip_test.cc
+++ b/cxx/emissions/bitflip_test.cc
@@ -2,11 +2,10 @@
 
 #define BOOST_TEST_MODULE test BitFlip
 
-#include <random>
-
 #include "emissions/bitflip.hh"
 
 #include <boost/test/included/unit_test.hpp>
+#include <random>
 
 BOOST_AUTO_TEST_CASE(test_simple) {
   BitFlip bf;

--- a/cxx/emissions/gaussian.hh
+++ b/cxx/emissions/gaussian.hh
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "emissions/base.hh"
 #include "distributions/zero_mean_normal.hh"
+#include "emissions/base.hh"
 
 class GaussianEmission : public Emission<double> {
  public:
   ZeroMeanNormal zmn;
 
-  GaussianEmission() : zmn(nullptr) {}
+  GaussianEmission() {}
 
   void incorporate(const std::pair<double, double>& x) {
     ++N;
@@ -23,17 +23,14 @@ class GaussianEmission : public Emission<double> {
     return zmn.logp(x.second - x.first);
   }
 
-  double logp_score() const {
-    return zmn.logp_score();
-  }
+  double logp_score() const { return zmn.logp_score(); }
 
-  void transition_hyperparameters() {
-    zmn.transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng) {
+    zmn.transition_hyperparameters(prng);
   }
 
   double sample_corrupted(const double& clean, std::mt19937* prng) {
-    zmn.prng = prng;
-    return clean + zmn.sample();
+    return clean + zmn.sample(prng);
   }
 
   double propose_clean(const std::vector<double>& corrupted,

--- a/cxx/emissions/simple_string.hh
+++ b/cxx/emissions/simple_string.hh
@@ -19,7 +19,7 @@ class SimpleStringEmission : public Emission<std::string> {
   BetaBernoulli insertions;
   BetaBernoulli deletions;
 
-  SimpleStringEmission(){};
+  SimpleStringEmission() {};
 
   void incorporate(const std::pair<std::string, std::string>& x) {
     ++N;

--- a/cxx/emissions/simple_string_test.cc
+++ b/cxx/emissions/simple_string_test.cc
@@ -2,11 +2,10 @@
 
 #define BOOST_TEST_MODULE test SimpleString
 
-#include <random>
-
 #include "emissions/simple_string.hh"
 
 #include <boost/test/included/unit_test.hpp>
+#include <random>
 
 BOOST_AUTO_TEST_CASE(test_simple) {
   SimpleStringEmission ss;
@@ -45,12 +44,14 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   ss.incorporate(std::make_pair<std::string, std::string>("hello", "hello"));
   BOOST_TEST(ss.N == 2);
 
-  BOOST_TEST(ss.logp(std::make_pair<std::string, std::string>("test", "tst")) < 0.0);
+  BOOST_TEST(ss.logp(std::make_pair<std::string, std::string>("test", "tst")) <
+             0.0);
   BOOST_TEST(ss.N == 2);
   // Since we have incorporated one substitution and no deletions, we should
   // expect substitutions to be more likely.
   double lp1 = ss.logp(std::make_pair<std::string, std::string>("test", "tst"));
-  double lp2 = ss.logp(std::make_pair<std::string, std::string>("test", "te$t"));
+  double lp2 =
+      ss.logp(std::make_pair<std::string, std::string>("test", "te$t"));
   BOOST_TEST(lp1 < lp2);
 
   std::mt19937 prng;
@@ -58,6 +59,6 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   BOOST_TEST(corrupted.length() > 3);
   BOOST_TEST(corrupted.length() < 7);
 
-  BOOST_TEST(ss.propose_clean({"clean", "clean!", "cl5an", "lean"}, &prng)
-             == "clean");
+  BOOST_TEST(ss.propose_clean({"clean", "clean!", "cl5an", "lean"}, &prng) ==
+             "clean");
 }

--- a/cxx/emissions/sometimes.hh
+++ b/cxx/emissions/sometimes.hh
@@ -15,7 +15,7 @@ class Sometimes : public Emission<SampleType> {
   BetaBernoulli bb;
   BaseEmissor be;
 
-  Sometimes(){};
+  Sometimes() {};
 
   void incorporate(const std::pair<SampleType, SampleType>& x) {
     ++(this->N);

--- a/cxx/emissions/sometimes.hh
+++ b/cxx/emissions/sometimes.hh
@@ -15,7 +15,7 @@ class Sometimes : public Emission<SampleType> {
   BetaBernoulli bb;
   BaseEmissor be;
 
-  Sometimes() : bb(nullptr) {};
+  Sometimes(){};
 
   void incorporate(const std::pair<SampleType, SampleType>& x) {
     ++(this->N);
@@ -37,18 +37,15 @@ class Sometimes : public Emission<SampleType> {
     return bb.logp(x.first != x.second) + be.logp(x);
   }
 
-  double logp_score() const {
-    return bb.logp_score() + be.logp_score();
-  }
+  double logp_score() const { return bb.logp_score() + be.logp_score(); }
 
-  void transition_hyperparameters() {
-    be.transition_hyperparameters();
-    bb.transition_hyperparameters();
+  void transition_hyperparameters(std::mt19937* prng) {
+    be.transition_hyperparameters(prng);
+    bb.transition_hyperparameters(prng);
   }
 
   SampleType sample_corrupted(const SampleType& clean, std::mt19937* prng) {
-    bb.prng = prng;
-    if (bb.sample()) {
+    if (bb.sample(prng)) {
       return be.sample_corrupted(clean, prng);
     }
     return clean;
@@ -63,7 +60,7 @@ class Sometimes : public Emission<SampleType> {
     std::unordered_map<SampleType, int> counts;
     SampleType mode;
     int max_count = 0;
-    for (const SampleType& c: corrupted) {
+    for (const SampleType& c : corrupted) {
       ++counts[c];
       if (counts[c] > max_count) {
         max_count = counts[c];

--- a/cxx/emissions/sometimes_test.cc
+++ b/cxx/emissions/sometimes_test.cc
@@ -2,12 +2,12 @@
 
 #define BOOST_TEST_MODULE test Sometimes
 
-#include <random>
-
-#include "emissions/bitflip.hh"
 #include "emissions/sometimes.hh"
 
 #include <boost/test/included/unit_test.hpp>
+#include <random>
+
+#include "emissions/bitflip.hh"
 
 BOOST_AUTO_TEST_CASE(test_simple) {
   Sometimes<BitFlip, bool> sbf;

--- a/cxx/relation_test.cc
+++ b/cxx/relation_test.cc
@@ -15,21 +15,21 @@ namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_relation) {
   std::mt19937 prng;
-  Domain D1("D1", &prng);
-  Domain D2("D2", &prng);
-  Domain D3("D3", &prng);
-  D1.incorporate(0);
-  D2.incorporate(1);
-  D3.incorporate(3);
+  Domain D1("D1");
+  Domain D2("D2");
+  Domain D3("D3");
+  D1.incorporate(&prng, 0);
+  D2.incorporate(&prng, 1);
+  D3.incorporate(&prng, 3);
   DistributionSpec spec = DistributionSpec{DistributionEnum::bernoulli};
-  Relation<BetaBernoulli> R1("R1", spec, {&D1, &D2, &D3}, &prng);
-  R1.incorporate({0, 1, 3}, 1);
-  R1.incorporate({1, 1, 3}, 1);
-  R1.incorporate({3, 1, 3}, 1);
-  R1.incorporate({4, 1, 3}, 1);
-  R1.incorporate({5, 1, 3}, 1);
-  R1.incorporate({0, 1, 4}, 0);
-  R1.incorporate({0, 1, 6}, 1);
+  Relation<BetaBernoulli> R1("R1", spec, {&D1, &D2, &D3});
+  R1.incorporate(&prng, {0, 1, 3}, 1);
+  R1.incorporate(&prng, {1, 1, 3}, 1);
+  R1.incorporate(&prng, {3, 1, 3}, 1);
+  R1.incorporate(&prng, {4, 1, 3}, 1);
+  R1.incorporate(&prng, {5, 1, 3}, 1);
+  R1.incorporate(&prng, {0, 1, 4}, 0);
+  R1.incorporate(&prng, {0, 1, 6}, 1);
   auto z1 = R1.get_cluster_assignment({0, 1, 3});
   BOOST_TEST(z1.size() == 3);
   BOOST_TEST(z1[0] == 0);
@@ -48,11 +48,11 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   R1.set_cluster_assignment_gibbs(D1, 0, 1);
 
   DistributionSpec bigram_spec = DistributionSpec{DistributionEnum::bigram};
-  Relation<Bigram> R2("R1", bigram_spec, {&D2, &D3}, &prng);
-  R2.incorporate({1, 3}, "cat");
-  R2.incorporate({1, 2}, "dog");
-  R2.incorporate({1, 4}, "catt");
-  R2.incorporate({2, 6}, "fish");
+  Relation<Bigram> R2("R1", bigram_spec, {&D2, &D3});
+  R2.incorporate(&prng, {1, 3}, "cat");
+  R2.incorporate(&prng, {1, 2}, "dog");
+  R2.incorporate(&prng, {1, 4}, "catt");
+  R2.incorporate(&prng, {2, 6}, "fish");
 
   lpg = R2.logp_gibbs_approx(D2, 2, 0);
   R2.set_cluster_assignment_gibbs(D3, 3, 1);

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
 
   HIRM hirm(schema_unary, &prng);
   printf("--- initialized HIRM --- \n");
-  incorporate_observations(hirm, encoding_unary, observations_unary);
+  incorporate_observations(&prng, hirm, encoding_unary, observations_unary);
   printf("--- incorporated observations --- \n");
   size_t n_obs_unary = 0;
   for (const auto& [z, irm] : hirm.irms) {
@@ -37,21 +37,21 @@ int main(int argc, char** argv) {
   }
   assert(n_obs_unary == std::size(observations_unary));
 
-  hirm.transition_cluster_assignments_all();
-  hirm.transition_cluster_assignments_all();
+  hirm.transition_cluster_assignments_all(&prng);
+  hirm.transition_cluster_assignments_all(&prng);
   printf("--- made transition cluster assignments --- \n");
-  hirm.set_cluster_assignment_gibbs("solitary", 120);
-  hirm.set_cluster_assignment_gibbs("water", 741);
+  hirm.set_cluster_assignment_gibbs(&prng, "solitary", 120);
+  hirm.set_cluster_assignment_gibbs(&prng, "water", 741);
   printf("--- set cluster assignments --- \n");
   for (int i = 0; i < 20; i++) {
-    hirm.transition_cluster_assignments_all();
+    hirm.transition_cluster_assignments_all(&prng);
     for (const auto& [t, irm] : hirm.irms) {
-      irm->transition_cluster_assignments_all();
+      irm->transition_cluster_assignments_all(&prng);
       for (const auto& [d, domain] : irm->domains) {
-        domain->crp.transition_alpha();
+        domain->crp.transition_alpha(&prng);
       }
     }
-    hirm.crp.transition_alpha();
+    hirm.crp.transition_alpha(&prng);
     printf("%d %f [", i, hirm.logp_score());
     for (const auto& [t, customers] : hirm.crp.tables) {
       printf("%ld ", customers.size());
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
 
   // Load the clusters.
   HIRM hirx({}, &prng);
-  from_txt(&hirx, path_schema, path_obs, path_clusters);
+  from_txt(&prng, &hirx, path_schema, path_obs, path_clusters);
 
   assert(hirm.irms.size() == hirx.irms.size());
   // Check IRMs agree.

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -41,13 +41,13 @@ int main(int argc, char** argv) {
   auto observations = load_observations(path_obs, schema);
   T_encoding encoding = encode_observations(schema, observations);
 
-  IRM irm(schema, &prng);
-  incorporate_observations(irm, encoding, observations);
+  IRM irm(schema);
+  incorporate_observations(&prng, irm, encoding, observations);
   printf("running for %d iterations\n", iters);
   for (int i = 0; i < iters; i++) {
-    irm.transition_cluster_assignments_all();
+    irm.transition_cluster_assignments_all(&prng);
     for (auto const& [d, domain] : irm.domains) {
-      domain->crp.transition_alpha();
+      domain->crp.transition_alpha(&prng);
     }
     double x = irm.logp_score();
     printf("iter %d, score %f\n", i, x);
@@ -102,8 +102,8 @@ int main(int argc, char** argv) {
     assert(abs(Z) < 1e-10);
   }
 
-  IRM irx({}, &prng);
-  from_txt(&irx, path_schema, path_obs, path_clusters);
+  IRM irx({});
+  from_txt(&prng, &irx, path_schema, path_obs, path_clusters);
   // Check log scores agree.
   for (const auto& d : {"D1", "D2"}) {
     auto dm = irm.domains.at(d);

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
       {"R2", T_relation{{"D1", "D2"}, DistributionSpec {DistributionEnum::normal}}},
       {"R3", T_relation{{"D3", "D1"}, DistributionSpec {DistributionEnum::bigram}}}
   };
-  IRM irm(schema1, &prng);
+  IRM irm(schema1);
 
   for (auto const& kv : irm.domains) {
     printf("%s %s; ", kv.first.c_str(), kv.second->name.c_str());
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     printf("\n");
   }
 
-  IRM irm3(schema, &prng);
+  IRM irm3(schema);
   auto observations = load_observations("assets/animals.binary.obs", schema);
   auto encoding = encode_observations(schema, observations);
   auto item_to_code = std::get<0>(encoding);
@@ -86,14 +86,14 @@ int main(int argc, char** argv) {
       items_code.push_back(code);
     }
     printf("\n");
-    irm3.incorporate(relation, items_code, value);
+    irm3.incorporate(&prng, relation, items_code, value);
   }
 
   for (int i = 0; i < 4; i++) {
-    irm3.transition_cluster_assignments({"animal", "feature"});
-    irm3.transition_cluster_assignments_all();
+    irm3.transition_cluster_assignments(&prng, {"animal", "feature"});
+    irm3.transition_cluster_assignments_all(&prng);
     for (auto const& [d, domain] : irm3.domains) {
-      domain->crp.transition_alpha();
+      domain->crp.transition_alpha(&prng);
     }
     double x = irm3.logp_score();
     printf("iter %d, score %f\n", i, x);
@@ -112,8 +112,8 @@ int main(int argc, char** argv) {
   printf("log prob of has(tail, bat)=1 is %1.2f\n", lp1);
   printf("logsumexp is %1.2f\n", lp_01);
 
-  IRM irm4({}, &prng);
-  from_txt(&irm4, "assets/animals.binary.schema", "assets/animals.binary.obs",
+  IRM irm4({});
+  from_txt(&prng, &irm4, "assets/animals.binary.schema", "assets/animals.binary.obs",
            path_clusters);
   irm4.domains.at("animal")->crp.alpha = irm3.domains.at("animal")->crp.alpha;
   irm4.domains.at("feature")->crp.alpha = irm3.domains.at("feature")->crp.alpha;

--- a/cxx/util_distribution_variant.cc
+++ b/cxx/util_distribution_variant.cc
@@ -60,20 +60,19 @@ DistributionSpec parse_distribution_spec(const std::string& dist_str) {
   }
 }
 
-DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec,
-                                            std::mt19937* prng) {
+DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec) {
   switch (spec.distribution) {
     case DistributionEnum::bernoulli:
-      return new BetaBernoulli(prng);
+      return new BetaBernoulli;
     case DistributionEnum::bigram:
-      return new Bigram(prng);
+      return new Bigram;
     case DistributionEnum::categorical: {
       assert(spec.distribution_args.size() == 1);
       int num_categories = std::stoi(spec.distribution_args.at("k"));
-      return new DirichletCategorical(prng, num_categories);
+      return new DirichletCategorical(num_categories);
     }
     case DistributionEnum::normal:
-      return new Normal(prng);
+      return new Normal;
     default:
       assert(false && "Unsupported distribution enum value.");
   }
@@ -81,17 +80,16 @@ DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec,
 
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,
-                                   std::vector<Domain*>& domains,
-                                   std::mt19937* prng) {
+                                   std::vector<Domain*>& domains) {
   switch (dist_spec.distribution) {
     case DistributionEnum::bernoulli:
-      return new Relation<BetaBernoulli>(name, dist_spec, domains, prng);
+      return new Relation<BetaBernoulli>(name, dist_spec, domains);
     case DistributionEnum::bigram:
-      return new Relation<Bigram>(name, dist_spec, domains, prng);
+      return new Relation<Bigram>(name, dist_spec, domains);
     case DistributionEnum::categorical:
-      return new Relation<DirichletCategorical>(name, dist_spec, domains, prng);
+      return new Relation<DirichletCategorical>(name, dist_spec, domains);
     case DistributionEnum::normal:
-      return new Relation<Normal>(name, dist_spec, domains, prng);
+      return new Relation<Normal>(name, dist_spec, domains);
     default:
       assert(false && "Unsupported distribution enum value.");
   }

--- a/cxx/util_distribution_variant.hh
+++ b/cxx/util_distribution_variant.hh
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <map>
-#include <random>
 #include <string>
 #include <variant>
 #include <vector>
@@ -41,10 +40,8 @@ ObservationVariant observation_string_to_value(
 
 DistributionSpec parse_distribution_spec(const std::string& dist_str);
 
-DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec,
-                                            std::mt19937* prng);
+DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec);
 
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,
-                                   std::vector<Domain*>& domains,
-                                   std::mt19937* prng);
+                                   std::vector<Domain*>& domains);

--- a/cxx/util_distribution_variant_test.cc
+++ b/cxx/util_distribution_variant_test.cc
@@ -6,7 +6,6 @@
 
 #include <boost/test/included/unit_test.hpp>
 #include <iostream>
-#include <random>
 
 #include "distributions/beta_bernoulli.hh"
 #include "distributions/bigram.hh"
@@ -36,9 +35,8 @@ BOOST_AUTO_TEST_CASE(test_parse_distribution_spec) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cluster_prior_from_spec) {
-  std::mt19937 prng;
   DistributionSpec dc = {DistributionEnum::categorical, {{"k", "4"}}};
-  DistributionVariant dcdv = cluster_prior_from_spec(dc, &prng);
+  DistributionVariant dcdv = cluster_prior_from_spec(dc);
   DirichletCategorical* dcd = std::get<DirichletCategorical*>(dcdv);
   BOOST_TEST(dcd->counts.size() == 4);
 }

--- a/cxx/util_io.hh
+++ b/cxx/util_io.hh
@@ -9,7 +9,8 @@ typedef std::map<std::string, std::map<std::string, T_item>> T_encoding_f;
 typedef std::map<std::string, std::map<T_item, std::string>> T_encoding_r;
 typedef std::tuple<T_encoding_f, T_encoding_r> T_encoding;
 
-typedef std::tuple<std::string, std::vector<std::string>, ObservationVariant> T_observation;
+typedef std::tuple<std::string, std::vector<std::string>, ObservationVariant>
+    T_observation;
 typedef std::vector<T_observation> T_observations;
 
 typedef std::unordered_map<std::string, T_item> T_assignment;
@@ -17,13 +18,16 @@ typedef std::unordered_map<std::string, T_assignment> T_assignments;
 
 // disk IO
 T_schema load_schema(const std::string& path);
-T_observations load_observations(const std::string& path, const T_schema& schema);
+T_observations load_observations(const std::string& path,
+                                 const T_schema& schema);
 T_encoding encode_observations(const T_schema& schema,
                                const T_observations& observations);
 
-void incorporate_observations(IRM& irm, const T_encoding& encoding,
+void incorporate_observations(std::mt19937* prng, IRM& irm,
+                              const T_encoding& encoding,
                               const T_observations& observations);
-void incorporate_observations(HIRM& hirm, const T_encoding& encoding,
+void incorporate_observations(std::mt19937* prng, HIRM& hirm,
+                              const T_encoding& encoding,
                               const T_observations& observations);
 
 void to_txt(const std::string& path, const IRM& irm,
@@ -49,7 +53,9 @@ std::tuple<std::map<int, std::vector<std::string>>,  // x[table] = {relation
            >
 load_clusters_hirm(const std::string& path);
 
-void from_txt(IRM* const irm, const std::string& path_schema,
-              const std::string& path_obs, const std::string& path_clusters);
-void from_txt(HIRM* const irm, const std::string& path_schema,
-              const std::string& path_obs, const std::string& path_clusters);
+void from_txt(std::mt19937* prng, IRM* const irm,
+              const std::string& path_schema, const std::string& path_obs,
+              const std::string& path_clusters);
+void from_txt(std::mt19937* prng, HIRM* const irm,
+              const std::string& path_schema, const std::string& path_obs,
+              const std::string& path_clusters);


### PR DESCRIPTION
…s member.

I considered keeping prng as a member of (H)IRM, but plumbing it through added minimal code complexity and it seems better to pass it in where it's used instead of have it hidden in the class.

Closes #49 