### PR TITLE
Refactor Relation<DistributionType> to Relation<ValueType>

### DIFF
--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -51,6 +51,14 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "typename_playground",
+    srcs = ["typename_playground.cc"],
+    deps = [
+        ":util_distribution_variant",
+    ],
+)
+
 cc_library(
     name = "relation",
     hdrs = ["relation.hh"],

--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -55,6 +55,7 @@ cc_binary(
     name = "typename_playground",
     srcs = ["typename_playground.cc"],
     deps = [
+        ":relation_variant",
         ":util_distribution_variant",
     ],
 )

--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -73,7 +73,6 @@ cc_library(
         ":domain",
         ":relation",
         ":util_distribution_variant",
-        "//distributions",
     ],
 )
 
@@ -133,6 +132,7 @@ cc_test(
         "@boost//:test",
     ],
 )
+
 cc_test(
     name = "relation_test",
     srcs = ["relation_test.cc"],
@@ -140,6 +140,15 @@ cc_test(
         ":domain",
         ":relation",
         "//distributions",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "relation_variant_test",
+    srcs = ["relation_variant_test.cc"],
+    deps = [
+        ":relation_variant",
         "@boost//:test",
     ],
 )

--- a/cxx/distributions/base.hh
+++ b/cxx/distributions/base.hh
@@ -5,8 +5,7 @@ template <typename T>
 class Distribution {
   // Abstract base class for probability distributions in HIRM.
   // New distribution subclasses need to be added to
-  // `relation_variant` and `util_distribution_variant` to be used in the
-  // (H)IRM models.
+  // `util_distribution_variant` to be used in the (H)IRM models.
  public:
   typedef T SampleType;
   // N is the number of incorporated observations.

--- a/cxx/irm_test.cc
+++ b/cxx/irm_test.cc
@@ -27,6 +27,7 @@ BOOST_AUTO_TEST_CASE(test_irm) {
   auto obs0 = observation_string_to_value("0", DistributionEnum::bernoulli);
 
   double logp_x = irm.logp({{"R1", {1, 2}, obs0}});
+  BOOST_TEST(logp_x < 0.0);
 
   irm.incorporate(&prng, "R1", {1, 2}, obs0);
   double one_obs_score = irm.logp_score();

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -9,11 +9,6 @@
 #include <vector>
 
 #include "distributions/base.hh"
-#include "distributions/beta_bernoulli.hh"
-#include "distributions/bigram.hh"
-#include "distributions/crp.hh"
-#include "distributions/dirichlet_categorical.hh"
-#include "distributions/normal.hh"
 #include "domain.hh"
 #include "util_distribution_variant.hh"
 #include "util_hash.hh"
@@ -33,9 +28,11 @@ class T_relation {
   DistributionSpec distribution_spec;
 };
 
-template <typename ValueType>
+template <typename T>
 class Relation {
  public:
+  typedef T ValueType;
+
   // human-readable name
   const std::string name;
   // Relation spec.

--- a/cxx/relation_test.cc
+++ b/cxx/relation_test.cc
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   D2.incorporate(&prng, 1);
   D3.incorporate(&prng, 3);
   DistributionSpec spec = DistributionSpec{DistributionEnum::bernoulli};
-  Relation<BetaBernoulli> R1("R1", spec, {&D1, &D2, &D3});
+  Relation<bool> R1("R1", spec, {&D1, &D2, &D3});
   R1.incorporate(&prng, {0, 1, 3}, 1);
   R1.incorporate(&prng, {1, 1, 3}, 1);
   R1.incorporate(&prng, {3, 1, 3}, 1);
@@ -48,8 +48,13 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   lpg = R1.logp_gibbs_approx(D1, 0, 10);
   R1.set_cluster_assignment_gibbs(D1, 0, 1);
 
+  Distribution<bool>* db = R1.make_new_distribution();
+  BOOST_TEST(db->N == 0);
+  db->incorporate(false);
+  BOOST_TEST(db->N == 1);
+
   DistributionSpec bigram_spec = DistributionSpec{DistributionEnum::bigram};
-  Relation<Bigram> R2("R1", bigram_spec, {&D2, &D3});
+  Relation<std::string> R2("R1", bigram_spec, {&D2, &D3});
   R2.incorporate(&prng, {1, 3}, "cat");
   R2.incorporate(&prng, {1, 2}, "dog");
   R2.incorporate(&prng, {1, 4}, "catt");
@@ -58,4 +63,9 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   lpg = R2.logp_gibbs_approx(D2, 2, 0);
   R2.set_cluster_assignment_gibbs(D3, 3, 1);
   D1.set_cluster_assignment_gibbs(0, 1);
+
+  Distribution<std::string>* db2 = R2.make_new_distribution();
+  BOOST_TEST(db2->N == 0);
+  db2->incorporate("hello");
+  BOOST_TEST(db2->N == 1);
 }

--- a/cxx/relation_variant.cc
+++ b/cxx/relation_variant.cc
@@ -1,12 +1,13 @@
 // Copyright 2024
 // See LICENSE.txt
 
-#include "relation_variant.hh"
-
 #include <cassert>
+#include <type_traits>
 
 #include "domain.hh"
 #include "relation.hh"
+#include "relation_variant.hh"
+
 
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,
@@ -15,10 +16,24 @@ RelationVariant relation_from_spec(const std::string& name,
 
   RelationVariant rv;
 
+  // We want to go from dv to its SampleType.  This only takes five steps:
+  // 1. To go from the DistributionVariant dv to the underlying
+  //    Distribution pointer, we use a std::visit.
+  // 2. To get the type of the Distribution, we use decltype(*v).
+  // 3. But that turns out to be of type DistributionName&, so we need to use
+  //    a std::remove_reference_t to get rid of the &.
+  // 4. You would think that we could now just access ::SampleType and be done,
+  //    but no -- that expression is sufficiently complicated that the C++
+  //    parser gets confused and throws an error about "dependent-name ... is
+  //    parsed as a non-type".  Luckily the same error message also gives the
+  //    fix:  just add a typename to the beginning.
+  // 5. With that, we can finally access the SampleType and use it to construct
+  //    the right kind of Relation.
   std::visit(
       [&](const auto& v) {
-      rv = new Relation<decltype(*v)::SampleType>(
-          name, dist_spec, domains);
+        rv = new Relation<typename
+            std::remove_reference_t<decltype(*v)>::SampleType>(
+                name, dist_spec, domains);
       }, dv);
 
   return rv;

--- a/cxx/relation_variant.cc
+++ b/cxx/relation_variant.cc
@@ -5,26 +5,21 @@
 
 #include <cassert>
 
-#include "distributions/beta_bernoulli.hh"
-#include "distributions/bigram.hh"
-#include "distributions/dirichlet_categorical.hh"
-#include "distributions/normal.hh"
 #include "domain.hh"
 #include "relation.hh"
 
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,
                                    std::vector<Domain*>& domains) {
-  switch (dist_spec.distribution) {
-    case DistributionEnum::bernoulli:
-      return new Relation<BetaBernoulli>(name, dist_spec, domains);
-    case DistributionEnum::bigram:
-      return new Relation<Bigram>(name, dist_spec, domains);
-    case DistributionEnum::categorical:
-      return new Relation<DirichletCategorical>(name, dist_spec, domains);
-    case DistributionEnum::normal:
-      return new Relation<Normal>(name, dist_spec, domains);
-    default:
-      assert(false && "Unsupported distribution enum value.");
-  }
+  DistributionVariant dv = cluster_prior_from_spec(dist_spec);
+
+  RelationVariant rv;
+
+  std::visit(
+      [&](const auto& v) {
+      rv = new Relation<decltype(*v)::SampleType>(
+          name, dist_spec, domains);
+      }, dv);
+
+  return rv;
 }

--- a/cxx/relation_variant.hh
+++ b/cxx/relation_variant.hh
@@ -7,11 +7,9 @@
 #include <variant>
 #include <vector>
 
+#include "domain.hh"
+#include "relation.hh"
 #include "util_distribution_variant.hh"
-
-class Domain;
-template <typename ValueType>
-class Relation;
 
 using RelationVariant =
     std::variant<Relation<std::string>*, Relation<double>*,

--- a/cxx/relation_variant.hh
+++ b/cxx/relation_variant.hh
@@ -9,17 +9,13 @@
 
 #include "util_distribution_variant.hh"
 
-class BetaBernoulli;
-class Bigram;
-class DirichletCategorical;
-class Normal;
 class Domain;
-template <typename DistributionType>
+template <typename ValueType>
 class Relation;
 
 using RelationVariant =
-    std::variant<Relation<BetaBernoulli>*, Relation<Bigram>*,
-                 Relation<DirichletCategorical>*, Relation<Normal>*>;
+    std::variant<Relation<std::string>*, Relation<double>*,
+                 Relation<int>*, Relation<bool>*>;
 
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,

--- a/cxx/relation_variant_test.cc
+++ b/cxx/relation_variant_test.cc
@@ -7,8 +7,9 @@
 #include <boost/test/included/unit_test.hpp>
 namespace tt = boost::test_tools;
 
-BOOST_AUTO_TEST_CASE(relation_from_spec) {
+BOOST_AUTO_TEST_CASE(test_relation_variant) {
   std::vector<Domain *> domains;
+  domains.push_back(new Domain("D1"));
   RelationVariant rv = relation_from_spec(
       "r1", parse_distribution_spec("bernoulli"), domains);
   Relation<bool>* rb = std::get<Relation<bool>*>(rv);

--- a/cxx/relation_variant_test.cc
+++ b/cxx/relation_variant_test.cc
@@ -1,0 +1,16 @@
+// Apache License, Version 2.0, refer to LICENSE.txt
+
+#define BOOST_TEST_MODULE test relation_variant
+
+#include "relation_variant.hh"
+
+#include <boost/test/included/unit_test.hpp>
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(relation_from_spec) {
+  std::vector<Domain *> domains;
+  RelationVariant rv = relation_from_spec(
+      "r1", parse_distribution_spec("bernoulli"), domains);
+  Relation<bool>* rb = std::get<Relation<bool>*>(rv);
+  BOOST_TEST(rb->name == "r1");
+}

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -137,8 +137,8 @@ int main(int argc, char** argv) {
     }
     // Check relations agree.
     for (const auto& [r, rm_var] : irm->relations) {
-      auto rx = std::get<Relation<BetaBernoulli>*>(irx->relations.at(r));
-      auto rm = std::get<Relation<BetaBernoulli>*>(rm_var);
+      auto rx = std::get<Relation<bool>*>(irx->relations.at(r));
+      auto rm = std::get<Relation<bool>*>(rm_var);
       assert(rm->data == rx->data);
       assert(rm->data_r == rx->data_r);
       assert(rm->clusters.size() == rx->clusters.size());

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -15,7 +15,7 @@
 #include "util_io.hh"
 #include "util_math.hh"
 
-using T_r = Relation<BetaBernoulli>*;
+using T_r = Relation<bool>*;
 
 int main(int argc, char** argv) {
   std::string path_base = "assets/two_relations";

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -111,12 +111,13 @@ int main(int argc, char** argv) {
   // transitioned.
   assert(abs(irx.logp_score() - irm.logp_score()) > 1e-8);
   for (const auto& r : {"R1", "R2"}) {
-    auto r1m = std::get<Relation<BetaBernoulli>*>(irm.relations.at(r));
-    auto r1x = std::get<Relation<BetaBernoulli>*>(irx.relations.at(r));
+    auto r1m = std::get<Relation<bool>*>(irm.relations.at(r));
+    auto r1x = std::get<Relation<bool>*>(irx.relations.at(r));
     for (const auto& [c, distribution] : r1m->clusters) {
-      auto dx = r1x->clusters.at(c);
-      dx->alpha = distribution->alpha;
-      dx->beta = distribution->beta;
+      auto dx = reinterpret_cast<BetaBernoulli*>(r1x->clusters.at(c));
+      auto dy = reinterpret_cast<BetaBernoulli*>(distribution);
+      dx->alpha = dy->alpha;
+      dx->beta = dy->beta;
     }
   }
   assert(abs(irx.logp_score() - irm.logp_score()) < 1e-8);

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
   std::string path_clusters = "assets/animals.binary.irm";
   to_txt(path_clusters, irm3, encoding);
 
-  auto rel = std::get<Relation<BetaBernoulli>*>(irm3.relations.at("has"));
+  auto rel = std::get<Relation<bool>*>(irm3.relations.at("has"));
   auto& enc = std::get<0>(encoding);
   auto lp0 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 0);
   auto lp1 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 1);
@@ -128,8 +128,8 @@ int main(int argc, char** argv) {
     assert(d3->crp.alpha == d4->crp.alpha);
   }
   for (const auto& r : {"has"}) {
-    auto r3 = std::get<Relation<BetaBernoulli>*>(irm3.relations.at(r));
-    auto r4 = std::get<Relation<BetaBernoulli>*>(irm4.relations.at(r));
+    auto r3 = std::get<Relation<bool>*>(irm3.relations.at(r));
+    auto r4 = std::get<Relation<bool>*>(irm4.relations.at(r));
     assert(r3->data == r4->data);
     assert(r3->data_r == r4->data_r);
     assert(r3->clusters.size() == r4->clusters.size());

--- a/cxx/typename_playground.cc
+++ b/cxx/typename_playground.cc
@@ -1,4 +1,6 @@
 
+#include "domain.hh"
+#include "relation_variant.hh"
 #include "util_distribution_variant.hh"
 
 #include <type_traits>
@@ -51,4 +53,13 @@ int main() {
         std::cout << "typename std::remove_reference_t<decltype(*v)>::SampleType = " <<
                   type_name<typename std::remove_reference_t<decltype(*v)>::SampleType>() << '\n';
       }, dv);
+
+  std::vector<Domain*> domains;
+  domains.push_back(new Domain("D1"));
+  RelationVariant rv = relation_from_spec("r1", dist_spec, domains);
+
+  std::visit(
+      [&](const auto& relv) {
+        std::cout << "decltype(*relv) = " << type_name<decltype(*relv)>() << '\n';
+      }, rv);
 }

--- a/cxx/typename_playground.cc
+++ b/cxx/typename_playground.cc
@@ -1,0 +1,54 @@
+
+#include "util_distribution_variant.hh"
+
+#include <type_traits>
+#include <typeinfo>
+#ifndef _MSC_VER
+#   include <cxxabi.h>
+#endif
+#include <memory>
+#include <string>
+#include <cstdlib>
+#include <iostream>
+
+template <class T>
+std::string
+type_name()
+{
+    typedef typename std::remove_reference<T>::type TR;
+    std::unique_ptr<char, void(*)(void*)> own
+           (
+#ifndef _MSC_VER
+                abi::__cxa_demangle(typeid(TR).name(), nullptr,
+                                           nullptr, nullptr),
+#else
+                nullptr,
+#endif
+                std::free
+           );
+    std::string r = own != nullptr ? own.get() : typeid(TR).name();
+    if (std::is_const<TR>::value)
+        r += " const";
+    if (std::is_volatile<TR>::value)
+        r += " volatile";
+    if (std::is_lvalue_reference<T>::value)
+        r += "&";
+    else if (std::is_rvalue_reference<T>::value)
+        r += "&&";
+    return r;
+}
+
+
+int main() {
+  DistributionSpec dist_spec = parse_distribution_spec("bernoulli");
+  DistributionVariant dv = cluster_prior_from_spec(dist_spec);
+
+  std::visit(
+      [&](const auto& v) {
+        std::cout << "decltype(*v) = " << type_name<decltype(*v)>() << '\n';
+        std::cout << "std::remove_reference_t<decltype(*v)> = " <<
+                  type_name<std::remove_reference_t<decltype(*v)>>() << '\n';
+        std::cout << "typename std::remove_reference_t<decltype(*v)>::SampleType = " <<
+                  type_name<typename std::remove_reference_t<decltype(*v)>::SampleType>() << '\n';
+      }, dv);
+}

--- a/cxx/util_distribution_variant.hh
+++ b/cxx/util_distribution_variant.hh
@@ -11,10 +11,10 @@
 #include <variant>
 #include <vector>
 
-class BetaBernoulli;
-class Bigram;
-class DirichletCategorical;
-class Normal;
+#include "distributions/beta_bernoulli.hh"
+#include "distributions/bigram.hh"
+#include "distributions/dirichlet_categorical.hh"
+#include "distributions/normal.hh"
 
 enum class DistributionEnum { bernoulli, bigram, categorical, normal };
 

--- a/cxx/util_distribution_variant.hh
+++ b/cxx/util_distribution_variant.hh
@@ -2,8 +2,7 @@
 // See LICENSE.txt
 
 // Classes and functions for dealing with Distributions and their values in a
-// generic manner.  When a new subclass is added, this file and
-// relation_variant.{hh,cc} will need to be updated.
+// generic manner.  When a new subclass is added, this file needs to be updated.
 
 #pragma once
 


### PR DESCRIPTION
This has lots of advantages, including the fact that new Distributions no longer need to touch relation_variant.*
In general, I think it is a code smell for a class to be templated over a type that doesn't appear in its methods (ValueType appears in Relation's  methods, but DistributionType doesn't .)

Plus fixed some memory leaks.

Plus added a typename_playground that makes it easier to iteratively write decltype and typename code and figure out what is going wrong.