### PR TITLE
Add transition_theta to outer inference code

### DIFF
--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -10,6 +10,7 @@ cc_library(
         ":crp",
         ":dirichlet_categorical",
         ":normal",
+        ":skellam",
     ],
 )
 

--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -86,6 +86,7 @@ cc_library(
 
 cc_library(
     name = "skellam",
+    srcs = ["skellam.cc"],
     hdrs = ["skellam.hh"],
     deps = [
         ":nonconjugate",

--- a/cxx/distributions/nonconjugate.hh
+++ b/cxx/distributions/nonconjugate.hh
@@ -24,7 +24,7 @@ class NonconjugateDistribution : public Distribution<T> {
   virtual void init_theta(std::mt19937* prng) = 0;
 
   // Return the current latent values as a vector.
-  virtual std::vector<double> store_latents() = 0;
+  virtual std::vector<double> store_latents() const = 0;
 
   // Set the current latent values from a vector.
   virtual void set_latents(const std::vector<double>& v) = 0;

--- a/cxx/distributions/skellam.cc
+++ b/cxx/distributions/skellam.cc
@@ -1,0 +1,66 @@
+#include "distributions/skellam.hh"
+
+#include <cassert>
+#include <cmath>
+#include "util_math.hh"
+
+double lognormal_logp(double x, double mean, double stddev) {
+  double y = (std::log(x) - mean) / stddev;
+  return - y*y / 2.0
+      - std::log(x * stddev) - 0.5 * std::log(2.0 * std::numbers::pi);
+}
+
+double Skellam::logp(const int&x) const {
+  return -mu1 - mu2 + (x / 2.0) * std::log(mu1 / mu2)
+      // TODO(thomaswc): Replace this with something more numerically stable.
+      + std::log(std::cyl_bessel_i(x, 2.0 * std::sqrt(mu1 * mu2)));
+}
+
+int Skellam::sample(std::mt19937* prng) {
+  std::poisson_distribution<int> d1(mu1);
+  std::poisson_distribution<int> d2(mu2);
+  return d1(*prng) - d2(*prng);
+}
+
+void Skellam::transition_hyperparameters(std::mt19937* prng) {
+  std::vector<double> logps;
+  std::vector<std::tuple<double, double, double, double>> hypers;
+  for (double tmean1 : MEAN_GRID) {
+    for (double tstddev1 : STDDEV_GRID) {
+      for (double tmean2 : MEAN_GRID) {
+        for (double tstddev2 : STDDEV_GRID) {
+          double lp = lognormal_logp(mu1, tmean1, tstddev1)
+              + lognormal_logp(mu2, tmean2, tstddev2);
+          logps.push_back(lp);
+          hypers.push_back(
+              std::make_tuple(tmean1, tstddev1, tmean2, tstddev2));
+        }
+      }
+    }
+  }
+  int i = sample_from_logps(logps, prng);
+  mean1 = std::get<0>(hypers[i]);
+  stddev1 = std::get<1>(hypers[i]);
+  mean2 = std::get<2>(hypers[i]);
+  stddev2 = std::get<3>(hypers[i]);
+}
+
+void Skellam::init_theta(std::mt19937* prng) {
+  std::normal_distribution<double> d1(mean1, stddev1);
+  std::normal_distribution<double> d2(mean2, stddev2);
+  mu1 = std::exp(d1(*prng));
+  mu2 = std::exp(d2(*prng));
+}
+
+std::vector<double> Skellam::store_latents() const {
+  std::vector<double> v;
+  v.push_back(mu1);
+  v.push_back(mu2);
+  return v;
+}
+
+void Skellam::set_latents(const std::vector<double>& v) {
+  assert(v.size() == 2);
+  mu1 = v[0];
+  mu2 = v[1];
+}

--- a/cxx/distributions/skellam.hh
+++ b/cxx/distributions/skellam.hh
@@ -1,19 +1,9 @@
 #pragma once
 
-#include <cassert>
-#include <cmath>
-
 #include "distributions/nonconjugate.hh"
-#include "util_math.hh"
 
 #define MEAN_GRID { -10.0, 0.0, 10.0 }
 #define STDDEV_GRID { 0.1, 1.0, 10.0 }
-
-double lognormal_logp(double x, double mean, double stddev) {
-  double y = (std::log(x) - mean) / stddev;
-  return - y*y / 2.0
-      - std::log(x * stddev) - 0.5 * std::log(2.0 * std::numbers::pi);
-}
 
 class Skellam : public NonconjugateDistribution<int> {
  public:
@@ -25,59 +15,15 @@ class Skellam : public NonconjugateDistribution<int> {
   Skellam(): mean1(0.0), mean2(0.0), stddev1(1.0), stddev2(1.0),
              mu1(1.0), mu2(1.0) {}
 
-  double logp(const int& x) const {
-    return -mu1 - mu2 + (x / 2.0) * std::log(mu1 / mu2)
-        // TODO(thomaswc): Replace this with something more numerically stable.
-        + std::log(std::cyl_bessel_i(x, 2.0 * std::sqrt(mu1 * mu2)));
-  }
+  double logp(const int& x) const;
 
-  int sample(std::mt19937* prng) {
-    std::poisson_distribution<int> d1(mu1);
-    std::poisson_distribution<int> d2(mu2);
-    return d1(*prng) - d2(*prng);
-  }
+  int sample(std::mt19937* prng);
 
-  void transition_hyperparameters(std::mt19937* prng) {
-    std::vector<double> logps;
-    std::vector<std::tuple<double, double, double, double>> hypers;
-    for (double tmean1 : MEAN_GRID) {
-      for (double tstddev1 : STDDEV_GRID) {
-        for (double tmean2 : MEAN_GRID) {
-          for (double tstddev2 : STDDEV_GRID) {
-            double lp = lognormal_logp(mu1, tmean1, tstddev1)
-                        + lognormal_logp(mu2, tmean2, tstddev2);
-            logps.push_back(lp);
-            hypers.push_back(
-                std::make_tuple(tmean1, tstddev1, tmean2, tstddev2));
-          }
-        }
-      }
-    }
-    int i = sample_from_logps(logps, prng);
-    mean1 = std::get<0>(hypers[i]);
-    stddev1 = std::get<1>(hypers[i]);
-    mean2 = std::get<2>(hypers[i]);
-    stddev2 = std::get<3>(hypers[i]);
-  }
+  void transition_hyperparameters(std::mt19937* prng);
 
-  void init_theta(std::mt19937* prng) {
-    std::normal_distribution<double> d1(mean1, stddev1);
-    std::normal_distribution<double> d2(mean2, stddev2);
-    mu1 = std::exp(d1(*prng));
-    mu2 = std::exp(d2(*prng));
-  }
+  void init_theta(std::mt19937* prng);
 
-  std::vector<double> store_latents() {
-    std::vector<double> v;
-    v.push_back(mu1);
-    v.push_back(mu2);
-    return v;
-  }
+  std::vector<double> store_latents() const;
 
-  void set_latents(const std::vector<double>& v) {
-    assert(v.size() == 2);
-    mu1 = v[0];
-    mu2 = v[1];
-  }
-
+  void set_latents(const std::vector<double>& v);
 };

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -205,7 +205,7 @@ void HIRM::remove_relation(const std::string& name) {
 
 double HIRM::logp(
     const std::vector<std::tuple<std::string, T_items, ObservationVariant>>&
-    observations) {
+    observations, std::mt19937* prng) {
   std::unordered_map<
       int, std::vector<std::tuple<std::string, T_items, ObservationVariant>>>
       obs_dict;
@@ -219,7 +219,7 @@ double HIRM::logp(
   }
   double logp = 0.0;
   for (const auto& [t, o] : obs_dict) {
-    logp += irms.at(t)->logp(o);
+    logp += irms.at(t)->logp(o, prng);
   }
   return logp;
 }

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -49,7 +49,7 @@ class HIRM {
 
   double logp(
       const std::vector<std::tuple<std::string, T_items, ObservationVariant>>&
-          observations);
+          observations, std::mt19937* prng);
 
   double logp_score() const;
 

--- a/cxx/irm.cc
+++ b/cxx/irm.cc
@@ -74,7 +74,7 @@ void IRM::transition_cluster_assignment_item(std::mt19937* prng,
   auto accumulate_logps = [&](auto rel) {
     if (rel->has_observation(*domain, item)) {
       std::vector<double> lp_relation =
-          rel->logp_gibbs_exact(*domain, item, tables);
+          rel->logp_gibbs_exact(*domain, item, tables, prng);
       assert(lp_relation.size() == tables.size());
       assert(lp_relation.size() == logps.size());
       for (int i = 0; i < std::ssize(logps); ++i) {
@@ -93,7 +93,7 @@ void IRM::transition_cluster_assignment_item(std::mt19937* prng,
   if (choice != domain->get_cluster_assignment(item)) {
     auto set_cluster_r = [&](auto rel) {
       if (rel->has_observation(*domain, item)) {
-        rel->set_cluster_assignment_gibbs(*domain, item, choice);
+        rel->set_cluster_assignment_gibbs(*domain, item, choice, prng);
       }
     };
     for (const std::string& r : domain_to_relations.at(d)) {
@@ -105,7 +105,7 @@ void IRM::transition_cluster_assignment_item(std::mt19937* prng,
 
 double IRM::logp(
     const std::vector<std::tuple<std::string, T_items, ObservationVariant>>&
-    observations) {
+    observations, std::mt19937* prng) {
   std::unordered_map<std::string, std::unordered_set<T_items, H_items>>
       relation_items_seen;
   std::unordered_map<std::string, std::unordered_set<T_item>>
@@ -199,7 +199,7 @@ double IRM::logp(
           typename std::remove_reference_t<decltype(*rel)>::ValueType>(value);
       auto prior =
           std::get<typename std::remove_reference_t<decltype(*rel)>::DType*>(
-              cluster_prior_from_spec(rel->dist_spec));
+              cluster_prior_from_spec(rel->dist_spec, prng));
       return rel->clusters.contains(z) ? rel->clusters.at(z)->logp(v)
           : prior->logp(v);
     };
@@ -290,7 +290,7 @@ void IRM::remove_relation(const std::string& name) {
   }
 
 void single_step_irm_inference(std::mt19937* prng, IRM* irm, double& t_total,
-                               bool verbose) {
+                               bool verbose, int num_theta_steps = 10) {
   // TRANSITION ASSIGNMENTS.
   for (const auto& [d, domain] : irm->domains) {
     for (const auto item : domain->items) {
@@ -305,6 +305,9 @@ void single_step_irm_inference(std::mt19937* prng, IRM* irm, double& t_total,
         [&](auto r) {
           for (const auto& [c, distribution] : r->clusters) {
             clock_t t = clock();
+            for (int i = 0; i < num_theta_steps; ++i ) {
+              distribution->transition_theta(prng);
+            }
             distribution->transition_hyperparameters(prng);
             REPORT_SCORE(verbose, t, t_total, irm);
           }

--- a/cxx/irm.cc
+++ b/cxx/irm.cc
@@ -290,7 +290,7 @@ void IRM::remove_relation(const std::string& name) {
   }
 
 void single_step_irm_inference(std::mt19937* prng, IRM* irm, double& t_total,
-                               bool verbose, int num_theta_steps = 10) {
+                               bool verbose, int num_theta_steps) {
   // TRANSITION ASSIGNMENTS.
   for (const auto& [d, domain] : irm->domains) {
     for (const auto item : domain->items) {

--- a/cxx/irm.cc
+++ b/cxx/irm.cc
@@ -200,7 +200,7 @@ double IRM::logp(
       if (rel->clusters.contains(z)) {
         return rel->clusters.at(z)->logp(v);
       }
-      DistributionVariant prior = cluster_prior_from_spec(rel->dist_spec);
+      DistributionVariant prior = cluster_prior_from_spec(rel->dist_spec, prng);
       return std::visit(
           [&](const auto& dist_variant) {
             auto v2 = std::get<

--- a/cxx/irm.hh
+++ b/cxx/irm.hh
@@ -41,7 +41,7 @@ class IRM {
                                           const T_item& item);
   double logp(
       const std::vector<std::tuple<std::string, T_items, ObservationVariant>>&
-          observations);
+          observations, std::mt19937* prng);
 
   double logp_score() const;
 

--- a/cxx/irm.hh
+++ b/cxx/irm.hh
@@ -57,4 +57,4 @@ class IRM {
 
 // Run a single step of inference on an IRM model.
 void single_step_irm_inference(std::mt19937* prng, IRM* irm, double& t_total,
-                               bool verbose);
+                               bool verbose, int num_theta_steps = 10);

--- a/cxx/irm_test.cc
+++ b/cxx/irm_test.cc
@@ -27,6 +27,7 @@ BOOST_AUTO_TEST_CASE(test_irm) {
   auto obs0 = observation_string_to_value("0", DistributionEnum::bernoulli);
 
   double logp_x = irm.logp({{"R1", {1, 2}, obs0}}, &prng);
+  BOOST_TEST(logp_x < 0.0);
 
   irm.incorporate(&prng, "R1", {1, 2}, obs0);
   double one_obs_score = irm.logp_score();

--- a/cxx/irm_test.cc
+++ b/cxx/irm_test.cc
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(test_irm) {
 
   auto obs0 = observation_string_to_value("0", DistributionEnum::bernoulli);
 
-  double logp_x = irm.logp({{"R1", {1, 2}, obs0}});
+  double logp_x = irm.logp({{"R1", {1, 2}, obs0}}, &prng);
 
   irm.incorporate(&prng, "R1", {1, 2}, obs0);
   double one_obs_score = irm.logp_score();

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -192,11 +192,11 @@ class Relation {
   }
 
   double logp_gibbs_approx(const Domain& domain, const T_item& item,
-                           int table) {
+                           int table, std::mt19937* prng) {
     int table_current = domain.get_cluster_assignment(item);
     return table_current == table
                ? logp_gibbs_approx_current(domain, item)
-               : logp_gibbs_approx_variant(domain, item, table);
+               : logp_gibbs_approx_variant(domain, item, table, prng);
   }
 
   // Implementation of exact Gibbs data probabilities.
@@ -271,7 +271,7 @@ class Relation {
       for (const auto& [z, items_list] : cluster_to_items_list) {
         lp_cluster =
             (table == table_current)
-                ? logp_gibbs_exact_current(items_list, prng)
+                ? logp_gibbs_exact_current(items_list)
                 : logp_gibbs_exact_variant(domain, item, table, items_list, prng);
         lp_table += lp_cluster;
       }

--- a/cxx/relation_test.cc
+++ b/cxx/relation_test.cc
@@ -43,10 +43,10 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   BOOST_TEST(z2[2] == 0);
 
   double lpg __attribute__ ((unused));
-  lpg = R1.logp_gibbs_approx(D1, 0, 1);
-  lpg = R1.logp_gibbs_approx(D1, 0, 0);
-  lpg = R1.logp_gibbs_approx(D1, 0, 10);
-  R1.set_cluster_assignment_gibbs(D1, 0, 1);
+  lpg = R1.logp_gibbs_approx(D1, 0, 1, &prng);
+  lpg = R1.logp_gibbs_approx(D1, 0, 0, &prng);
+  lpg = R1.logp_gibbs_approx(D1, 0, 10, &prng);
+  R1.set_cluster_assignment_gibbs(D1, 0, 1, &prng);
 
   DistributionSpec bigram_spec = DistributionSpec{DistributionEnum::bigram};
   Relation<Bigram> R2("R1", bigram_spec, {&D2, &D3});
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   R2.incorporate(&prng, {1, 4}, "catt");
   R2.incorporate(&prng, {2, 6}, "fish");
 
-  lpg = R2.logp_gibbs_approx(D2, 2, 0);
-  R2.set_cluster_assignment_gibbs(D3, 3, 1);
+  lpg = R2.logp_gibbs_approx(D2, 2, 0, &prng);
+  R2.set_cluster_assignment_gibbs(D3, 3, 1, &prng);
   D1.set_cluster_assignment_gibbs(0, 1);
 }

--- a/cxx/relation_test.cc
+++ b/cxx/relation_test.cc
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   lpg = R1.logp_gibbs_approx(D1, 0, 10, &prng);
   R1.set_cluster_assignment_gibbs(D1, 0, 1, &prng);
 
-  Distribution<bool>* db = R1.make_new_distribution();
+  Distribution<bool>* db = R1.make_new_distribution(&prng);
   BOOST_TEST(db->N == 0);
   db->incorporate(false);
   BOOST_TEST(db->N == 1);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(test_relation) {
   R2.set_cluster_assignment_gibbs(D3, 3, 1, &prng);
   D1.set_cluster_assignment_gibbs(0, 1);
 
-  Distribution<std::string>* db2 = R2.make_new_distribution();
+  Distribution<std::string>* db2 = R2.make_new_distribution(&prng);
   BOOST_TEST(db2->N == 0);
   db2->incorporate("hello");
   BOOST_TEST(db2->N == 1);

--- a/cxx/relation_variant.cc
+++ b/cxx/relation_variant.cc
@@ -2,6 +2,7 @@
 // See LICENSE.txt
 
 #include <cassert>
+#include <random>
 #include <type_traits>
 
 #include "domain.hh"
@@ -12,7 +13,8 @@
 RelationVariant relation_from_spec(const std::string& name,
                                    const DistributionSpec& dist_spec,
                                    std::vector<Domain*>& domains) {
-  DistributionVariant dv = cluster_prior_from_spec(dist_spec);
+  std::mt19937 prng;
+  DistributionVariant dv = cluster_prior_from_spec(dist_spec, &prng);
 
   RelationVariant rv;
 

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -75,14 +75,14 @@ int main(int argc, char** argv) {
 
   // Marginally normalized.
   int persiancat = enc["animal"]["persiancat"];
-  auto p0_black_persiancat = hirm.logp({{"black", {persiancat}, false}});
-  auto p1_black_persiancat = hirm.logp({{"black", {persiancat}, true}});
+  auto p0_black_persiancat = hirm.logp({{"black", {persiancat}, false}}, &prng);
+  auto p1_black_persiancat = hirm.logp({{"black", {persiancat}, true}}, &prng);
   assert(abs(logsumexp({p0_black_persiancat, p1_black_persiancat})) < 1e-10);
 
   // Marginally normalized.
   int sheep = enc["animal"]["sheep"];
-  auto p0_solitary_sheep = hirm.logp({{"solitary", {sheep}, false}});
-  auto p1_solitary_sheep = hirm.logp({{"solitary", {sheep}, true}});
+  auto p0_solitary_sheep = hirm.logp({{"solitary", {sheep}, false}}, &prng);
+  auto p1_solitary_sheep = hirm.logp({{"solitary", {sheep}, true}}, &prng);
   assert(abs(logsumexp({p0_solitary_sheep, p1_solitary_sheep})) < 1e-10);
 
   // Jointly normalized.

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -87,13 +87,13 @@ int main(int argc, char** argv) {
 
   // Jointly normalized.
   auto p00_black_persiancat_solitary_sheep =
-      hirm.logp({{"black", {persiancat}, false}, {"solitary", {sheep}, false}});
+      hirm.logp({{"black", {persiancat}, false}, {"solitary", {sheep}, false}}, &prng);
   auto p01_black_persiancat_solitary_sheep =
-      hirm.logp({{"black", {persiancat}, false}, {"solitary", {sheep}, true}});
+      hirm.logp({{"black", {persiancat}, false}, {"solitary", {sheep}, true}}, &prng);
   auto p10_black_persiancat_solitary_sheep =
-      hirm.logp({{"black", {persiancat}, true}, {"solitary", {sheep}, false}});
+      hirm.logp({{"black", {persiancat}, true}, {"solitary", {sheep}, false}}, &prng);
   auto p11_black_persiancat_solitary_sheep =
-      hirm.logp({{"black", {persiancat}, true}, {"solitary", {sheep}, true}});
+      hirm.logp({{"black", {persiancat}, true}, {"solitary", {sheep}, true}}, &prng);
   auto Z = logsumexp({
       p00_black_persiancat_solitary_sheep,
       p01_black_persiancat_solitary_sheep,

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -91,10 +91,10 @@ int main(int argc, char** argv) {
     auto x1 = l.at(0);
     auto x2 = l.at(1);
     auto x3 = l.at(2);
-    auto p00 = irm.logp({{"R1", {x1, x2}, false}, {"R1", {x1, x3}, false}});
-    auto p01 = irm.logp({{"R1", {x1, x2}, false}, {"R1", {x1, x3}, true}});
-    auto p10 = irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, false}});
-    auto p11 = irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, true}});
+    auto p00 = irm.logp({{"R1", {x1, x2}, false}, {"R1", {x1, x3}, false}}, &prng);
+    auto p01 = irm.logp({{"R1", {x1, x2}, false}, {"R1", {x1, x3}, true}}, &prng);
+    auto p10 = irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, false}}, &prng);
+    auto p11 = irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, true}}, &prng);
     auto Z = logsumexp({p00, p01, p10, p11});
     assert(abs(Z) < 1e-10);
   }

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -77,10 +77,10 @@ int main(int argc, char** argv) {
     assert(l.size() == 2);
     auto x1 = l.at(0);
     auto x2 = l.at(1);
-    auto p0 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, false);
-    auto p0_irm = irm.logp({{"R1", {x1, x2}, false}});
+    auto p0 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, false, &prng);
+    auto p0_irm = irm.logp({{"R1", {x1, x2}, false}}, &prng);
     assert(abs(p0 - p0_irm) < 1e-10);
-    auto p1 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, true);
+    auto p1 = std::get<T_r>(irm.relations.at("R1"))->logp({x1, x2}, true, &prng);
     auto Z = logsumexp({p0, p1});
     assert(abs(Z) < 1e-10);
     assert(abs(exp(p0) - expected_p0[x1].at(x2)) < .1);

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -104,8 +104,8 @@ int main(int argc, char** argv) {
 
   auto rel = std::get<Relation<BetaBernoulli>*>(irm3.relations.at("has"));
   auto& enc = std::get<0>(encoding);
-  auto lp0 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 0);
-  auto lp1 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 1);
+  auto lp0 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 0, &prng);
+  auto lp1 = rel->logp({enc["animal"]["tail"], enc["animal"]["bat"]}, 1, &prng);
   auto lp_01 = logsumexp({lp0, lp1});
   assert(abs(lp_01) < 1e-5);
   printf("log prob of has(tail, bat)=0 is %1.2f\n", lp0);

--- a/cxx/typename_playground.cc
+++ b/cxx/typename_playground.cc
@@ -3,15 +3,16 @@
 #include "relation_variant.hh"
 #include "util_distribution_variant.hh"
 
-#include <type_traits>
-#include <typeinfo>
 #ifndef _MSC_VER
 #   include <cxxabi.h>
 #endif
-#include <memory>
-#include <string>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <typeinfo>
 
 template <class T>
 std::string
@@ -42,8 +43,9 @@ type_name()
 
 
 int main() {
+  std::mt19937 prng;
   DistributionSpec dist_spec = parse_distribution_spec("bernoulli");
-  DistributionVariant dv = cluster_prior_from_spec(dist_spec);
+  DistributionVariant dv = cluster_prior_from_spec(dist_spec, &prng);
 
   std::visit(
       [&](const auto& v) {

--- a/cxx/util_distribution_variant.cc
+++ b/cxx/util_distribution_variant.cc
@@ -11,6 +11,7 @@
 #include "distributions/crp.hh"
 #include "distributions/dirichlet_categorical.hh"
 #include "distributions/normal.hh"
+#include "distributions/skellam.hh"
 
 ObservationVariant observation_string_to_value(
     const std::string& value_str, const DistributionEnum& distribution) {
@@ -20,6 +21,7 @@ ObservationVariant observation_string_to_value(
     case DistributionEnum::bernoulli:
       return static_cast<bool>(std::stoi(value_str));
     case DistributionEnum::categorical:
+    case DistributionEnum::skellam:
       return std::stoi(value_str);
     case DistributionEnum::bigram:
       return value_str;
@@ -33,7 +35,9 @@ DistributionSpec parse_distribution_spec(const std::string& dist_str) {
       {"bernoulli", DistributionEnum::bernoulli},
       {"bigram", DistributionEnum::bigram},
       {"categorical", DistributionEnum::categorical},
-      {"normal", DistributionEnum::normal}};
+      {"normal", DistributionEnum::normal},
+      {"skellam", DistributionEnum::skellam}
+  };
   std::string dist_name = dist_str.substr(0, dist_str.find('('));
   DistributionEnum dist = dist_name_to_enum.at(dist_name);
 
@@ -58,7 +62,8 @@ DistributionSpec parse_distribution_spec(const std::string& dist_str) {
   }
 }
 
-DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec) {
+DistributionVariant cluster_prior_from_spec(
+    const DistributionSpec& spec, std::mt19937* prng) {
   switch (spec.distribution) {
     case DistributionEnum::bernoulli:
       return new BetaBernoulli;
@@ -71,6 +76,11 @@ DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec) {
     }
     case DistributionEnum::normal:
       return new Normal;
+    case DistributionEnum::skellam: {
+      Skellam* s = new Skellam;
+      s->init_theta(prng);
+      return s;
+    }
     default:
       assert(false && "Unsupported distribution enum value.");
   }

--- a/cxx/util_distribution_variant.hh
+++ b/cxx/util_distribution_variant.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <map>
+#include <random>
 #include <string>
 #include <variant>
 #include <vector>
@@ -16,8 +17,9 @@ class BetaBernoulli;
 class Bigram;
 class DirichletCategorical;
 class Normal;
+class Skellam;
 
-enum class DistributionEnum { bernoulli, bigram, categorical, normal };
+enum class DistributionEnum { bernoulli, bigram, categorical, normal, skellam };
 
 struct DistributionSpec {
   DistributionEnum distribution;
@@ -28,11 +30,13 @@ struct DistributionSpec {
 using ObservationVariant = std::variant<double, int, bool, std::string>;
 
 using DistributionVariant =
-    std::variant<BetaBernoulli*, Bigram*, DirichletCategorical*, Normal*>;
+    std::variant<BetaBernoulli*, Bigram*, DirichletCategorical*, Normal*,
+                 Skellam*>;
 
 ObservationVariant observation_string_to_value(
     const std::string& value_str, const DistributionEnum& distribution);
 
 DistributionSpec parse_distribution_spec(const std::string& dist_str);
 
-DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec);
+DistributionVariant cluster_prior_from_spec(const DistributionSpec& spec,
+                                            std::mt19937* prng);

--- a/cxx/util_distribution_variant_test.cc
+++ b/cxx/util_distribution_variant_test.cc
@@ -27,7 +27,11 @@ BOOST_AUTO_TEST_CASE(test_parse_distribution_spec) {
   BOOST_TEST((dn.distribution == DistributionEnum::normal));
   BOOST_TEST(dn.distribution_args.empty());
 
-  DistributionSpec dc = parse_distribution_spec("categorical(k=6)");
+  DistributionSpec s = parse_distribution_spec("skellam");
+  BOOST_TEST((dn.distribution == DistributionEnum::skellam));
+  BOOST_TEST(dn.distribution_args.empty());
+
+  DistributionSpec dc = parse_distribution_spec("categorical(k=6), &prng");
   BOOST_TEST((dc.distribution == DistributionEnum::categorical));
   BOOST_TEST((dc.distribution_args.size() == 1));
   std::string expected = "6";
@@ -35,8 +39,9 @@ BOOST_AUTO_TEST_CASE(test_parse_distribution_spec) {
 }
 
 BOOST_AUTO_TEST_CASE(test_cluster_prior_from_spec) {
+  std::mt19937 prng;
   DistributionSpec dc = {DistributionEnum::categorical, {{"k", "4"}}};
-  DistributionVariant dcdv = cluster_prior_from_spec(dc);
+  DistributionVariant dcdv = cluster_prior_from_spec(dc, &prng);
   DirichletCategorical* dcd = std::get<DirichletCategorical*>(dcdv);
   BOOST_TEST(dcd->counts.size() == 4);
 }

--- a/cxx/util_distribution_variant_test.cc
+++ b/cxx/util_distribution_variant_test.cc
@@ -27,11 +27,11 @@ BOOST_AUTO_TEST_CASE(test_parse_distribution_spec) {
   BOOST_TEST((dn.distribution == DistributionEnum::normal));
   BOOST_TEST(dn.distribution_args.empty());
 
-  DistributionSpec s = parse_distribution_spec("skellam");
-  BOOST_TEST((dn.distribution == DistributionEnum::skellam));
-  BOOST_TEST(dn.distribution_args.empty());
+  DistributionSpec ds = parse_distribution_spec("skellam");
+  BOOST_TEST((ds.distribution == DistributionEnum::skellam));
+  BOOST_TEST(ds.distribution_args.empty());
 
-  DistributionSpec dc = parse_distribution_spec("categorical(k=6), &prng");
+  DistributionSpec dc = parse_distribution_spec("categorical(k=6)");
   BOOST_TEST((dc.distribution == DistributionEnum::categorical));
   BOOST_TEST((dc.distribution_args.size() == 1));
   std::string expected = "6";


### PR DESCRIPTION
Also, add Skellam as an HIRM distribution.
Also (and this is actually the majority of this change), call init_theta when creating a non-conjugate distribution.  init_theta needs a random number generator, so a bunch of relation and irm methods now need to take one of those when they didn't before.
