### PR TITLE
Add emission class for Categorical distributions

### DIFF
--- a/cxx/emissions/BUILD
+++ b/cxx/emissions/BUILD
@@ -43,6 +43,16 @@ cc_library(
 )
 
 cc_library(
+    name = "categorical",
+    srcs = ["categorical.hh"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":base",
+        "//distributions:dirichlet_categorical",
+    ],
+)
+
+cc_library(
     name = "gaussian",
     srcs = ["gaussian.hh"],
     visibility = ["//:__subpackages__"],

--- a/cxx/emissions/BUILD
+++ b/cxx/emissions/BUILD
@@ -103,6 +103,15 @@ cc_test(
 )
 
 cc_test(
+    name = "categorical_test",
+    srcs = ["categorical_test.cc"],
+    deps = [
+        ":categorical",
+        "@boost//:algorithm",
+        "@boost//:test",
+    ],
+)
+cc_test(
     name = "gaussian_test",
     srcs = ["gaussian_test.cc"],
     deps = [

--- a/cxx/emissions/categorical.hh
+++ b/cxx/emissions/categorical.hh
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cassert>
+#include <limits>
+
+#include "distributions/dirichlet_categorical.hh"
+#include "emissions/base.hh"
+
+// A "bigram" emission model that tracks separate emission distributions per
+// clean categorical state.
+class CategoricalEmission : public Emission<int> {
+ public:
+  mutable std::vector<DirichletCateogrical> emission_dists;
+
+  CategoricalEmission(int num_states) {
+    emission_dists.reserve(num_states);
+    for (int i = 0; i < num_states; ++i) {
+      emission_dists.emplace_back(num_states);
+    }
+  };
+
+  void incorporate(const std::pair<int, int>& x) {
+    ++N;
+    emission_dists[x.first].incorporate(x.second);
+  }
+
+  void unincorporate(const std::pair<int, int>& x) {
+    --N;
+    emission_dists[x.first].unincorporate(x.second);
+  }
+
+  double logp(const std::pair<int, int>& x) const {
+    double lp;
+    for (int i = 0; i < emission_dists.length(); ++i) {
+      if (i == x.first) {
+        lp += emission_dists[i].logp(x.second);
+      } else {
+        lp += emission_dists[i].logp_score();
+      }
+    }
+    return lp;
+  }
+
+  double logp_score() const {
+    double lp = 0.0;
+    for (const auto& e : emission_dists) {
+      lp += e.logp_score();
+    }
+    return lp;
+  }
+
+  void transition_hyperparameters(std::mt19937* prng) {
+    for (auto& e : emission_dists) {
+      e.transition_hyperparameters(prng);
+    }
+  }
+
+  int sample_corrupted(const int& clean, std::mt19937* prng) {
+    return emission_dists[clean].sample(prng);
+  }
+
+  int propose_clean(const std::vector<int>& corrupted,
+                     std::mt19937* unused_prng) {
+    // Brute force; compute log prob over all possible clean states.
+    int best_clean;
+    double best_clean_logp = std::numeric_limits<double>::lowest();
+    for (int i = 0; i < emission_dists.length(); ++i) {
+      double lp = 0.0;
+      for (const auto& c : corrupted) {
+        lp += emission_dists[i].logp(c);
+      }
+      if (lp > best_clean_logp) {
+        best_clean = i;
+        best_clean_logp = lp;
+      }
+    }
+    return best_clean;
+  }
+
+};

--- a/cxx/emissions/categorical.hh
+++ b/cxx/emissions/categorical.hh
@@ -31,15 +31,7 @@ class CategoricalEmission : public Emission<int> {
   }
 
   double logp(const std::pair<int, int>& x) const {
-    double lp;
-    for (size_t i = 0; i < emission_dists.size(); ++i) {
-      if (std::cmp_equal(i, x.first)) {
-        lp += emission_dists[i].logp(x.second);
-      } else {
-        lp += emission_dists[i].logp_score();
-      }
-    }
-    return lp;
+    return emission_dists[x.first].logp(x.second);
   }
 
   double logp_score() const {

--- a/cxx/emissions/categorical.hh
+++ b/cxx/emissions/categorical.hh
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <limits>
+#include <utility>
 
 #include "distributions/dirichlet_categorical.hh"
 #include "emissions/base.hh"
@@ -10,7 +11,7 @@
 // clean categorical state.
 class CategoricalEmission : public Emission<int> {
  public:
-  mutable std::vector<DirichletCateogrical> emission_dists;
+  mutable std::vector<DirichletCategorical> emission_dists;
 
   CategoricalEmission(int num_states) {
     emission_dists.reserve(num_states);
@@ -31,8 +32,8 @@ class CategoricalEmission : public Emission<int> {
 
   double logp(const std::pair<int, int>& x) const {
     double lp;
-    for (int i = 0; i < emission_dists.length(); ++i) {
-      if (i == x.first) {
+    for (size_t i = 0; i < emission_dists.size(); ++i) {
+      if (std::cmp_equal(i, x.first)) {
         lp += emission_dists[i].logp(x.second);
       } else {
         lp += emission_dists[i].logp_score();
@@ -64,7 +65,7 @@ class CategoricalEmission : public Emission<int> {
     // Brute force; compute log prob over all possible clean states.
     int best_clean;
     double best_clean_logp = std::numeric_limits<double>::lowest();
-    for (int i = 0; i < emission_dists.length(); ++i) {
+    for (size_t i = 0; i < emission_dists.size(); ++i) {
       double lp = 0.0;
       for (const auto& c : corrupted) {
         lp += emission_dists[i].logp(c);

--- a/cxx/emissions/categorical_test.cc
+++ b/cxx/emissions/categorical_test.cc
@@ -6,29 +6,31 @@
 
 #include <boost/test/included/unit_test.hpp>
 #include <random>
+namespace tt = boost::test_tools;
 
 BOOST_AUTO_TEST_CASE(test_simple) {
   CategoricalEmission ce(5);
 
-  BOOST_TEST(ce.logp_score() = 0.0);
+  BOOST_TEST(ce.logp_score() == 0.0);
   BOOST_TEST(ce.N == 0);
   ce.incorporate(std::make_pair<int, int>(0, 2));
-  BOOST_TEST(ce.N == 0);
-  BOOST_TEST(ce.logp_score() = 0.0);
+  BOOST_TEST(ce.N == 1);
+  BOOST_TEST(ce.logp_score() == -1.6094379124341001, tt::tolerance(1e-6));
   ce.unincorporate(std::make_pair<int, int>(0, 2));
   BOOST_TEST(ce.N == 0);
   ce.incorporate(std::make_pair<int, int>(3, 3));
   ce.incorporate(std::make_pair<int, int>(4, 4));
   BOOST_TEST(ce.N == 2);
 
-  BOOST_TEST(ce.logp(std::make_pair<int, int>(2, 2)) == 0.0);
+  BOOST_TEST(ce.logp(std::make_pair<int, int>(2, 2)) == -4.8283137373023006,
+             tt::tolerance(1e-6));
 
   std::mt19937 prng;
-  int s = bf.sample_corrupted(1, &prng);
+  int s = ce.sample_corrupted(1, &prng);
   BOOST_TEST(s < 5);
   BOOST_TEST(s >= 0);
 
-  int clean = bf.propose_clean({1, 1, 3, 4}, &prng);
+  int clean = ce.propose_clean({1, 1, 3, 4}, &prng);
   BOOST_TEST(clean < 5);
   BOOST_TEST(clean >= 0);
 }

--- a/cxx/emissions/categorical_test.cc
+++ b/cxx/emissions/categorical_test.cc
@@ -1,0 +1,34 @@
+// Apache License, Version 2.0, refer to LICENSE.txt
+
+#define BOOST_TEST_MODULE test CategoricalEmission
+
+#include "emissions/categorical.hh"
+
+#include <boost/test/included/unit_test.hpp>
+#include <random>
+
+BOOST_AUTO_TEST_CASE(test_simple) {
+  CategoricalEmission ce(5);
+
+  BOOST_TEST(ce.logp_score() = 0.0);
+  BOOST_TEST(ce.N == 0);
+  ce.incorporate(std::make_pair<int, int>(0, 2));
+  BOOST_TEST(ce.N == 0);
+  BOOST_TEST(ce.logp_score() = 0.0);
+  ce.unincorporate(std::make_pair<int, int>(0, 2));
+  BOOST_TEST(ce.N == 0);
+  ce.incorporate(std::make_pair<int, int>(3, 3));
+  ce.incorporate(std::make_pair<int, int>(4, 4));
+  BOOST_TEST(ce.N == 2);
+
+  BOOST_TEST(ce.logp(std::make_pair<int, int>(2, 2)) == 0.0);
+
+  std::mt19937 prng;
+  int s = bf.sample_corrupted(1, &prng);
+  BOOST_TEST(s < 5);
+  BOOST_TEST(s >= 0);
+
+  int clean = bf.propose_clean({1, 1, 3, 4}, &prng);
+  BOOST_TEST(clean < 5);
+  BOOST_TEST(clean >= 0);
+}

--- a/cxx/emissions/categorical_test.cc
+++ b/cxx/emissions/categorical_test.cc
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   ce.incorporate(std::make_pair<int, int>(4, 4));
   BOOST_TEST(ce.N == 2);
 
-  BOOST_TEST(ce.logp(std::make_pair<int, int>(2, 2)) == -4.8283137373023006,
+  BOOST_TEST(ce.logp(std::make_pair<int, int>(2, 2)) == -1.6094379124341003,
              tt::tolerance(1e-6));
 
   std::mt19937 prng;


### PR DESCRIPTION
A later pull request will have the upgrades to the Sometimes emissions adapter that will let it be used in conjunction with this.