### PR TITLE
Update assert in clean relations to be approximate equality.

### DIFF
--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -258,7 +258,8 @@ class CleanRelation : public Relation<T> {
       ValueType x = data.at(items);
       cluster->incorporate(x);
     }
-    assert(cluster->logp_score() == logp0);
+    // Approximate floating point equality.
+    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * fabs(logp0));
     return logp0 - logp1;
   }
 
@@ -284,7 +285,9 @@ class CleanRelation : public Relation<T> {
       ValueType x = data.at(items);
       cluster->unincorporate(x);
     }
-    assert(cluster->logp_score() == logp0);
+
+    // Approximate floating point equality.
+    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * fabs(logp0));
     delete prior;
     return logp1 - logp0;
   }

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -259,7 +259,7 @@ class CleanRelation : public Relation<T> {
       cluster->incorporate(x);
     }
     // Approximate floating point equality.
-    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * fabs(logp0));
+    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * abs(logp0));
     return logp0 - logp1;
   }
 
@@ -287,7 +287,7 @@ class CleanRelation : public Relation<T> {
     }
 
     // Approximate floating point equality.
-    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * fabs(logp0));
+    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * abs(logp0));
     delete prior;
     return logp1 - logp0;
   }

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -259,7 +259,7 @@ class CleanRelation : public Relation<T> {
       cluster->incorporate(x);
     }
     // Approximate floating point equality.
-    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * abs(logp0));
+    assert(abs(cluster->logp_score() - logp0) <= std::numeric_limits<double>::epsilon() * abs(logp0));
     return logp0 - logp1;
   }
 
@@ -287,7 +287,7 @@ class CleanRelation : public Relation<T> {
     }
 
     // Approximate floating point equality.
-    assert(abs(cluster->logp_score() - logp0) < std::numeric_limits<double>::epsilon() * abs(logp0));
+    assert(abs(cluster->logp_score() - logp0) <= std::numeric_limits<double>::epsilon() * abs(logp0));
     delete prior;
     return logp1 - logp0;
   }


### PR DESCRIPTION
Update gibbs asserts to be approximate equality.

The reason this wasn't needed in the original HIRM is because sufficient statistics were ints. With the addition of real valued and other types of data, we have floating point sufficient statistics. Thus a call to incorporate/unincorporate should lead to something close to where we started, but might be slightly different numerically. Thus, the check is relaxed.