### PR TITLE
Update the schema for Model 4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,34 +108,35 @@ the relations in the system:
 
 ```
 $ cat assets/animals.unary.schema
-bernoulli black animal
-bernoulli white animal
-bernoulli blue animal
-bernoulli brown animal
-bernoulli gray animal
-bernoulli orange animal
-bernoulli red animal
-bernoulli yellow animal
-bernoulli patches animal
-bernoulli spots animal
+clean bernoulli black animal
+clean bernoulli white animal
+clean bernoulli blue animal
+clean bernoulli brown animal
+clean bernoulli gray animal
+clean bernoulli orange animal
+clean bernoulli red animal
+clean bernoulli yellow animal
+clean bernoulli patches animal
+clean bernoulli spots animal
 ...
 ```
 
 Each line specifies the signature of a relation in the system:
 
-- The first entry is the observation type
-  (only `bernoulli` is supported at the moment).
-- The second entry is the name of the relation (e.g., `black`); all the
+- The first entry indicates whether the relation is noisy (`"noisy"`) or not noisy (`"clean"`).
+- The second entry is the observation type. See the `DistributionSpec` definition for supported values for clean relations and the `EmissionSpec` definition for supported values for noisy relations.
+- The third entry is the name of the relation (e.g., `black`); all the
   relations names must be unique.
-- The third entry is the domain of the relation (in this example, the only
+- For noisy relations only, the fourth entry is the name of the base relation for which the relation models noisy observations.
+- The remaining entries are the domains of the relation (in this example, the only
   domain is `animal`).
 
-Thus, for this schema, we have a list of unary relations that each specify
+Thus, for this schema, we have a list of non-noisy unary relations that each specify
 whether an `animal` has a given attribute.
 
 Note that, in general a given relational system can be encoded in multiple
 ways. See `assets/animals.binary.schema` for an encoding of this system using
-a single higher-order relation with signature: `bernoulli has feature animal`.
+a single higher-order relation with signature: `clean bernoulli has feature animal`.
 
 #### Observation file
 

--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -233,6 +233,7 @@ filegroup(
     srcs = [
         "test_schema/nary.schema",
         "test_schema/all_types.schema",
+        "test_schema/with_noisy.schema",
     ],
 )
 

--- a/cxx/assets/animals.binary.schema
+++ b/cxx/assets/animals.binary.schema
@@ -1,1 +1,1 @@
-bernoulli has feature animal
+clean bernoulli has feature animal

--- a/cxx/assets/animals.unary.schema
+++ b/cxx/assets/animals.unary.schema
@@ -1,85 +1,85 @@
-bernoulli black animal
-bernoulli white animal
-bernoulli blue animal
-bernoulli brown animal
-bernoulli gray animal
-bernoulli orange animal
-bernoulli red animal
-bernoulli yellow animal
-bernoulli patches animal
-bernoulli spots animal
-bernoulli stripes animal
-bernoulli furry animal
-bernoulli hairless animal
-bernoulli toughskin animal
-bernoulli big animal
-bernoulli small animal
-bernoulli bulbous animal
-bernoulli lean animal
-bernoulli flippers animal
-bernoulli hands animal
-bernoulli hooves animal
-bernoulli pads animal
-bernoulli paws animal
-bernoulli longleg animal
-bernoulli longneck animal
-bernoulli tail animal
-bernoulli chewteeth animal
-bernoulli meatteeth animal
-bernoulli buckteeth animal
-bernoulli strainteeth animal
-bernoulli horns animal
-bernoulli claws animal
-bernoulli tusks animal
-bernoulli smelly animal
-bernoulli flys animal
-bernoulli hops animal
-bernoulli swims animal
-bernoulli tunnels animal
-bernoulli walks animal
-bernoulli fast animal
-bernoulli slow animal
-bernoulli strong animal
-bernoulli weak animal
-bernoulli muscle animal
-bernoulli bipedal animal
-bernoulli quadrapedal animal
-bernoulli active animal
-bernoulli inactive animal
-bernoulli nocturnal animal
-bernoulli hibernate animal
-bernoulli agility animal
-bernoulli fish animal
-bernoulli meat animal
-bernoulli plankton animal
-bernoulli vegetation animal
-bernoulli insects animal
-bernoulli forager animal
-bernoulli grazer animal
-bernoulli hunter animal
-bernoulli scavenger animal
-bernoulli skimmer animal
-bernoulli stalker animal
-bernoulli newworld animal
-bernoulli oldworld animal
-bernoulli arctic animal
-bernoulli coastal animal
-bernoulli desert animal
-bernoulli bush animal
-bernoulli plains animal
-bernoulli forest animal
-bernoulli fields animal
-bernoulli jungle animal
-bernoulli mountains animal
-bernoulli ocean animal
-bernoulli ground animal
-bernoulli water animal
-bernoulli tree animal
-bernoulli cave animal
-bernoulli fierce animal
-bernoulli timid animal
-bernoulli smart animal
-bernoulli group animal
-bernoulli solitary animal
-bernoulli nestspot animal
-bernoulli domestic animal
+clean bernoulli black animal
+clean bernoulli white animal
+clean bernoulli blue animal
+clean bernoulli brown animal
+clean bernoulli gray animal
+clean bernoulli orange animal
+clean bernoulli red animal
+clean bernoulli yellow animal
+clean bernoulli patches animal
+clean bernoulli spots animal
+clean bernoulli stripes animal
+clean bernoulli furry animal
+clean bernoulli hairless animal
+clean bernoulli toughskin animal
+clean bernoulli big animal
+clean bernoulli small animal
+clean bernoulli bulbous animal
+clean bernoulli lean animal
+clean bernoulli flippers animal
+clean bernoulli hands animal
+clean bernoulli hooves animal
+clean bernoulli pads animal
+clean bernoulli paws animal
+clean bernoulli longleg animal
+clean bernoulli longneck animal
+clean bernoulli tail animal
+clean bernoulli chewteeth animal
+clean bernoulli meatteeth animal
+clean bernoulli buckteeth animal
+clean bernoulli strainteeth animal
+clean bernoulli horns animal
+clean bernoulli claws animal
+clean bernoulli tusks animal
+clean bernoulli smelly animal
+clean bernoulli flys animal
+clean bernoulli hops animal
+clean bernoulli swims animal
+clean bernoulli tunnels animal
+clean bernoulli walks animal
+clean bernoulli fast animal
+clean bernoulli slow animal
+clean bernoulli strong animal
+clean bernoulli weak animal
+clean bernoulli muscle animal
+clean bernoulli bipedal animal
+clean bernoulli quadrapedal animal
+clean bernoulli active animal
+clean bernoulli inactive animal
+clean bernoulli nocturnal animal
+clean bernoulli hibernate animal
+clean bernoulli agility animal
+clean bernoulli fish animal
+clean bernoulli meat animal
+clean bernoulli plankton animal
+clean bernoulli vegetation animal
+clean bernoulli insects animal
+clean bernoulli forager animal
+clean bernoulli grazer animal
+clean bernoulli hunter animal
+clean bernoulli scavenger animal
+clean bernoulli skimmer animal
+clean bernoulli stalker animal
+clean bernoulli newworld animal
+clean bernoulli oldworld animal
+clean bernoulli arctic animal
+clean bernoulli coastal animal
+clean bernoulli desert animal
+clean bernoulli bush animal
+clean bernoulli plains animal
+clean bernoulli forest animal
+clean bernoulli fields animal
+clean bernoulli jungle animal
+clean bernoulli mountains animal
+clean bernoulli ocean animal
+clean bernoulli ground animal
+clean bernoulli water animal
+clean bernoulli tree animal
+clean bernoulli cave animal
+clean bernoulli fierce animal
+clean bernoulli timid animal
+clean bernoulli smart animal
+clean bernoulli group animal
+clean bernoulli solitary animal
+clean bernoulli nestspot animal
+clean bernoulli domestic animal

--- a/cxx/assets/nations.binary.schema
+++ b/cxx/assets/nations.binary.schema
@@ -1,2 +1,2 @@
-bernoulli has feature country
-bernoulli applies predicate country country
+clean bernoulli has feature country
+clean bernoulli applies predicate country country

--- a/cxx/assets/nations.unary.schema
+++ b/cxx/assets/nations.unary.schema
@@ -1,167 +1,167 @@
-bernoulli telephone country
-bernoulli agriculturalpop country
-bernoulli energyconsume country
-bernoulli illiterates country
-bernoulli GNP country
-bernoulli popxenergabs country
-bernoulli incomeabs country
-bernoulli popabs country
-bernoulli unassessment country
-bernoulli defenseexpabs country
-bernoulli englishtitles country
-bernoulli blocmembership0 country
-bernoulli usaidreceived country
-bernoulli freedomofopposition0 country
-bernoulli IFCandIBRD country
-bernoulli threats country
-bernoulli accusations country
-bernoulli killedforeignviolence country
-bernoulli militaryaction country
-bernoulli protests country
-bernoulli killeddomesticviolence country
-bernoulli riots country
-bernoulli purges country
-bernoulli demonstrations country
-bernoulli catholics country
-bernoulli airdistance country
-bernoulli medicinengo country
-bernoulli diplomatexpelled country
-bernoulli divorces country
-bernoulli popn/land country
-bernoulli arable country
-bernoulli area country
-bernoulli roadlength country
-bernoulli railroadlength country
-bernoulli religions country
-bernoulli immigrants/migrants country
-bernoulli rainfall country
-bernoulli largestrelgn country
-bernoulli runningwater country
-bernoulli foreigncollegestud country
-bernoulli neutralblock country
-bernoulli age country
-bernoulli religioustitles country
-bernoulli emigrants country
-bernoulli seabornegoods country
-bernoulli lawngos country
-bernoulli unemployed country
-bernoulli export country
-bernoulli languages country
-bernoulli largestlang country
-bernoulli ethnicgrps country
-bernoulli economicaidtaken country
-bernoulli techassistancetaken country
-bernoulli goveducationspend country
-bernoulli femaleworkers country
-bernoulli exports country
-bernoulli foreignmail country
-bernoulli imports country
-bernoulli caloriesconsumed country
-bernoulli protein country
-bernoulli russiantitles country
-bernoulli militarypersonnel country
-bernoulli investments country
-bernoulli politicalparties country
-bernoulli artsculturengo country
-bernoulli communistparty country
-bernoulli govspending country
-bernoulli monarchy country
-bernoulli primaryschool country
-bernoulli govchangelegal0 country
-bernoulli legitgov0 country
-bernoulli largestethnic country
-bernoulli assassinations country
-bernoulli majgovcrisis country
-bernoulli unpaymentdelinq country
-bernoulli balancepayments country
-bernoulli balanceinvestments country
-bernoulli systemstyle0 country
-bernoulli constitutional0 country
-bernoulli electoralsystem0 country
-bernoulli noncommunist country
-bernoulli politicalleadership0 country
-bernoulli horizontalpower0 country
-bernoulli military0 country
-bernoulli bureaucracy0 country
-bernoulli censorship0 country
-bernoulli geographyx country
-bernoulli geographyy country
-bernoulli geographyz country
-bernoulli blocmembership1 country
-bernoulli blocmembership2 country
-bernoulli freedomofopposition1 country
-bernoulli freedomofopposition2 country
-bernoulli govchangelegal1 country
-bernoulli govchangelegal2 country
-bernoulli legitgov1 country
-bernoulli systemstyle1 country
-bernoulli systemstyle2 country
-bernoulli constitutional1 country
-bernoulli constitutional2 country
-bernoulli electoralsystem1 country
-bernoulli electoralsystem2 country
-bernoulli politicalleadership1 country
-bernoulli politicalleadership2 country
-bernoulli horizontalpower2 country
-bernoulli military1 country
-bernoulli military2 country
-bernoulli bureaucracy1 country
-bernoulli bureaucracy2 country
-bernoulli censorship1 country
-bernoulli censorship2 country
-bernoulli economicaid country country
-bernoulli releconomicaid country country
-bernoulli treaties country country
-bernoulli reltreaties country country
-bernoulli officialvisits country country
-bernoulli conferences country country
-bernoulli exportbooks country country
-bernoulli relexportbooks country country
-bernoulli booktranslations country country
-bernoulli relbooktranslations country country
-bernoulli warning country country
-bernoulli violentactions country country
-bernoulli militaryactions country country
-bernoulli duration country country
-bernoulli negativebehavior country country
-bernoulli severdiplomatic country country
-bernoulli expeldiplomats country country
-bernoulli boycottembargo country country
-bernoulli aidenemy country country
-bernoulli negativecomm country country
-bernoulli accusation country country
-bernoulli protests_rel country country
-bernoulli unoffialacts country country
-bernoulli attackembassy country country
-bernoulli nonviolentbehavior country country
-bernoulli weightedunvote country country
-bernoulli unweightedunvote country country
-bernoulli tourism country country
-bernoulli reltourism country country
-bernoulli tourism3 country country
-bernoulli emigrants_rel country country
-bernoulli relemigrants country country
-bernoulli emigrants3 country country
-bernoulli students country country
-bernoulli relstudents country country
-bernoulli exports_rel country country
-bernoulli relexports country country
-bernoulli exports3 country country
-bernoulli intergovorgs country country
-bernoulli relintergovorgs country country
-bernoulli ngo country country
-bernoulli relngo country country
-bernoulli intergovorgs3 country country
-bernoulli ngoorgs3 country country
-bernoulli embassy country country
-bernoulli reldiplomacy country country
-bernoulli timesincewar country country
-bernoulli timesinceally country country
-bernoulli lostterritory country country
-bernoulli dependent country country
-bernoulli independence country country
-bernoulli commonbloc0 country country
-bernoulli blockpositionindex country country
-bernoulli militaryalliance country country
-bernoulli commonbloc1 country country
-bernoulli commonbloc2 country country
+clean bernoulli telephone country
+clean bernoulli agriculturalpop country
+clean bernoulli energyconsume country
+clean bernoulli illiterates country
+clean bernoulli GNP country
+clean bernoulli popxenergabs country
+clean bernoulli incomeabs country
+clean bernoulli popabs country
+clean bernoulli unassessment country
+clean bernoulli defenseexpabs country
+clean bernoulli englishtitles country
+clean bernoulli blocmembership0 country
+clean bernoulli usaidreceived country
+clean bernoulli freedomofopposition0 country
+clean bernoulli IFCandIBRD country
+clean bernoulli threats country
+clean bernoulli accusations country
+clean bernoulli killedforeignviolence country
+clean bernoulli militaryaction country
+clean bernoulli protests country
+clean bernoulli killeddomesticviolence country
+clean bernoulli riots country
+clean bernoulli purges country
+clean bernoulli demonstrations country
+clean bernoulli catholics country
+clean bernoulli airdistance country
+clean bernoulli medicinengo country
+clean bernoulli diplomatexpelled country
+clean bernoulli divorces country
+clean bernoulli popn/land country
+clean bernoulli arable country
+clean bernoulli area country
+clean bernoulli roadlength country
+clean bernoulli railroadlength country
+clean bernoulli religions country
+clean bernoulli immigrants/migrants country
+clean bernoulli rainfall country
+clean bernoulli largestrelgn country
+clean bernoulli runningwater country
+clean bernoulli foreigncollegestud country
+clean bernoulli neutralblock country
+clean bernoulli age country
+clean bernoulli religioustitles country
+clean bernoulli emigrants country
+clean bernoulli seabornegoods country
+clean bernoulli lawngos country
+clean bernoulli unemployed country
+clean bernoulli export country
+clean bernoulli languages country
+clean bernoulli largestlang country
+clean bernoulli ethnicgrps country
+clean bernoulli economicaidtaken country
+clean bernoulli techassistancetaken country
+clean bernoulli goveducationspend country
+clean bernoulli femaleworkers country
+clean bernoulli exports country
+clean bernoulli foreignmail country
+clean bernoulli imports country
+clean bernoulli caloriesconsumed country
+clean bernoulli protein country
+clean bernoulli russiantitles country
+clean bernoulli militarypersonnel country
+clean bernoulli investments country
+clean bernoulli politicalparties country
+clean bernoulli artsculturengo country
+clean bernoulli communistparty country
+clean bernoulli govspending country
+clean bernoulli monarchy country
+clean bernoulli primaryschool country
+clean bernoulli govchangelegal0 country
+clean bernoulli legitgov0 country
+clean bernoulli largestethnic country
+clean bernoulli assassinations country
+clean bernoulli majgovcrisis country
+clean bernoulli unpaymentdelinq country
+clean bernoulli balancepayments country
+clean bernoulli balanceinvestments country
+clean bernoulli systemstyle0 country
+clean bernoulli constitutional0 country
+clean bernoulli electoralsystem0 country
+clean bernoulli noncommunist country
+clean bernoulli politicalleadership0 country
+clean bernoulli horizontalpower0 country
+clean bernoulli military0 country
+clean bernoulli bureaucracy0 country
+clean bernoulli censorship0 country
+clean bernoulli geographyx country
+clean bernoulli geographyy country
+clean bernoulli geographyz country
+clean bernoulli blocmembership1 country
+clean bernoulli blocmembership2 country
+clean bernoulli freedomofopposition1 country
+clean bernoulli freedomofopposition2 country
+clean bernoulli govchangelegal1 country
+clean bernoulli govchangelegal2 country
+clean bernoulli legitgov1 country
+clean bernoulli systemstyle1 country
+clean bernoulli systemstyle2 country
+clean bernoulli constitutional1 country
+clean bernoulli constitutional2 country
+clean bernoulli electoralsystem1 country
+clean bernoulli electoralsystem2 country
+clean bernoulli politicalleadership1 country
+clean bernoulli politicalleadership2 country
+clean bernoulli horizontalpower2 country
+clean bernoulli military1 country
+clean bernoulli military2 country
+clean bernoulli bureaucracy1 country
+clean bernoulli bureaucracy2 country
+clean bernoulli censorship1 country
+clean bernoulli censorship2 country
+clean bernoulli economicaid country country
+clean bernoulli releconomicaid country country
+clean bernoulli treaties country country
+clean bernoulli reltreaties country country
+clean bernoulli officialvisits country country
+clean bernoulli conferences country country
+clean bernoulli exportbooks country country
+clean bernoulli relexportbooks country country
+clean bernoulli booktranslations country country
+clean bernoulli relbooktranslations country country
+clean bernoulli warning country country
+clean bernoulli violentactions country country
+clean bernoulli militaryactions country country
+clean bernoulli duration country country
+clean bernoulli negativebehavior country country
+clean bernoulli severdiplomatic country country
+clean bernoulli expeldiplomats country country
+clean bernoulli boycottembargo country country
+clean bernoulli aidenemy country country
+clean bernoulli negativecomm country country
+clean bernoulli accusation country country
+clean bernoulli protests_rel country country
+clean bernoulli unoffialacts country country
+clean bernoulli attackembassy country country
+clean bernoulli nonviolentbehavior country country
+clean bernoulli weightedunvote country country
+clean bernoulli unweightedunvote country country
+clean bernoulli tourism country country
+clean bernoulli reltourism country country
+clean bernoulli tourism3 country country
+clean bernoulli emigrants_rel country country
+clean bernoulli relemigrants country country
+clean bernoulli emigrants3 country country
+clean bernoulli students country country
+clean bernoulli relstudents country country
+clean bernoulli exports_rel country country
+clean bernoulli relexports country country
+clean bernoulli exports3 country country
+clean bernoulli intergovorgs country country
+clean bernoulli relintergovorgs country country
+clean bernoulli ngo country country
+clean bernoulli relngo country country
+clean bernoulli intergovorgs3 country country
+clean bernoulli ngoorgs3 country country
+clean bernoulli embassy country country
+clean bernoulli reldiplomacy country country
+clean bernoulli timesincewar country country
+clean bernoulli timesinceally country country
+clean bernoulli lostterritory country country
+clean bernoulli dependent country country
+clean bernoulli independence country country
+clean bernoulli commonbloc0 country country
+clean bernoulli blockpositionindex country country
+clean bernoulli militaryalliance country country
+clean bernoulli commonbloc1 country country
+clean bernoulli commonbloc2 country country

--- a/cxx/assets/pclean-flights-clean-flight-name.schema
+++ b/cxx/assets/pclean-flights-clean-flight-name.schema
@@ -1,1 +1,1 @@
-bigram has_name flight
+clean bigram has_name flight

--- a/cxx/assets/pclean-flights-clean-source-flight-name.schema
+++ b/cxx/assets/pclean-flights-clean-source-flight-name.schema
@@ -1,1 +1,1 @@
-bernoulli reports_on source flight
+clean bernoulli reports_on source flight

--- a/cxx/assets/pclean-flights-clean-unary.schema
+++ b/cxx/assets/pclean-flights-clean-unary.schema
@@ -1,6 +1,6 @@
-bigram src record
-bigram flight record
-bigram sched_dep_time record
-bigram act_dep_time record
-bigram sched_arr_time record
-bigram act_arr_time record
+clean bigram src record
+clean bigram flight record
+clean bigram sched_dep_time record
+clean bigram act_dep_time record
+clean bigram sched_arr_time record
+clean bigram act_arr_time record

--- a/cxx/assets/pclean-rents-clean-county-names.schema
+++ b/cxx/assets/pclean-rents-clean-county-names.schema
@@ -1,1 +1,1 @@
-bigram has_name County
+clean bigram has_name County

--- a/cxx/assets/pclean-rents-clean-ternary.schema
+++ b/cxx/assets/pclean-rents-clean-ternary.schema
@@ -1,3 +1,3 @@
-stringcat(strings=1br:2br:3br:4br:studio,delim=:) has_type record County State
-normal has_rent record County State
-bigram county_name County State
+clean stringcat(strings=1br:2br:3br:4br:studio,delim=:) has_type record County State
+clean normal has_rent record County State
+clean bigram county_name County State

--- a/cxx/assets/pclean-rents-clean-unary.schema
+++ b/cxx/assets/pclean-rents-clean-unary.schema
@@ -1,4 +1,4 @@
-stringcat(strings=1br:2br:3br:4br:studio,delim=:) Room-Type record
-skellam Monthly-Rent record
-bigram County record
-bigram State record
+clean stringcat(strings=1br:2br:3br:4br:studio,delim=:) Room-Type record
+clean skellam Monthly-Rent record
+clean bigram County record
+clean bigram State record

--- a/cxx/assets/test-mixture-2-normals.schema
+++ b/cxx/assets/test-mixture-2-normals.schema
@@ -1,1 +1,1 @@
-normal has_value id
+clean normal has_value id

--- a/cxx/assets/two_relations.schema
+++ b/cxx/assets/two_relations.schema
@@ -1,2 +1,2 @@
-bernoulli R1 D1 D2
-bernoulli R2 D1 D2
+clean bernoulli R1 D1 D2
+clean bernoulli R2 D1 D2

--- a/cxx/test_schema/all_types.schema
+++ b/cxx/test_schema/all_types.schema
@@ -1,6 +1,6 @@
-bernoulli R1 D1
-bigram R2 D1
-categorical(k=6) R3 D1
-normal R4 D1
-skellam R5 D1
-stringcat(strings=yes:no,delim=:) R6 D1
+clean bernoulli R1 D1
+clean bigram R2 D1
+clean categorical(k=6) R3 D1
+clean normal R4 D1
+clean skellam R5 D1
+clean stringcat(strings=yes:no,delim=:) R6 D1

--- a/cxx/test_schema/nary.schema
+++ b/cxx/test_schema/nary.schema
@@ -1,5 +1,5 @@
-bernoulli R1 D1
-bernoulli R2 D2
-bernoulli R3 D1 D2
-bernoulli R4 D1 D2 D3
-bernoulli R5 D1 D2 D3 D1
+clean bernoulli R1 D1
+clean bernoulli R2 D2
+clean bernoulli R3 D1 D2
+clean bernoulli R4 D1 D2 D3
+clean bernoulli R5 D1 D2 D3 D1

--- a/cxx/test_schema/with_noisy.schema
+++ b/cxx/test_schema/with_noisy.schema
@@ -1,0 +1,6 @@
+clean bernoulli R1 D1
+noisy gaussian R2 R6 D1 D2
+clean bigram R3 D2
+noisy gaussian R4 R2 D1 D2 D3
+noisy sometimes_bitflip R5 R1 D1
+clean normal R6 D1

--- a/cxx/util_io_test.cc
+++ b/cxx/util_io_test.cc
@@ -96,6 +96,52 @@ BOOST_AUTO_TEST_CASE(test_input_types) {
   BOOST_TEST(R6.domains[0] == "D1");
 }
 
+BOOST_AUTO_TEST_CASE(test_with_noisy) {
+  T_schema schema = load_schema("test_schema/with_noisy.schema");
+
+  BOOST_TEST(schema.contains("R1"));
+  T_clean_relation R1 = std::get<T_clean_relation>(schema["R1"]);
+  BOOST_TEST(
+      (R1.distribution_spec.distribution == DistributionEnum::bernoulli));
+  BOOST_TEST(R1.domains.size() == 1);
+  BOOST_TEST(R1.domains[0] == "D1");
+
+  BOOST_TEST(schema.contains("R2"));
+  T_noisy_relation R2 = std::get<T_noisy_relation>(schema["R2"]);
+  BOOST_TEST((R2.emission_spec.emission == EmissionEnum::gaussian));
+  BOOST_TEST(R2.domains.size() == 2);
+  BOOST_TEST(R2.domains[0] == "D1");
+  BOOST_TEST(R2.domains[1] == "D2");
+
+  BOOST_TEST(schema.contains("R3"));
+  T_clean_relation R3 = std::get<T_clean_relation>(schema["R3"]);
+  BOOST_TEST(
+      (R3.distribution_spec.distribution == DistributionEnum::bigram));
+  BOOST_TEST(R3.domains.size() == 1);
+  BOOST_TEST(R3.domains[0] == "D2");
+
+  BOOST_TEST(schema.contains("R4"));
+  T_noisy_relation R4 = std::get<T_noisy_relation>(schema["R4"]);
+  BOOST_TEST((R4.emission_spec.emission == EmissionEnum::gaussian));
+  BOOST_TEST(R4.domains.size() == 3);
+  BOOST_TEST(R4.domains[0] == "D1");
+  BOOST_TEST(R4.domains[1] == "D2");
+  BOOST_TEST(R4.domains[2] == "D3");
+
+  BOOST_TEST(schema.contains("R5"));
+  T_noisy_relation R5 = std::get<T_noisy_relation>(schema["R5"]);
+  BOOST_TEST((R5.emission_spec.emission == EmissionEnum::sometimes_bitflip));
+  BOOST_TEST(R5.domains.size() == 1);
+  BOOST_TEST(R5.domains[0] == "D1");
+
+  BOOST_TEST(schema.contains("R6"));
+  T_clean_relation R6 = std::get<T_clean_relation>(schema["R6"]);
+  BOOST_TEST(
+      (R6.distribution_spec.distribution == DistributionEnum::normal));
+  BOOST_TEST(R6.domains.size() == 1);
+  BOOST_TEST(R6.domains[0] == "D1");
+}
+
 BOOST_AUTO_TEST_CASE(test_incorporate_observations_irm) {
   T_clean_relation TR1({"D1", "D2"}, false, DistributionSpec("normal"));
   T_noisy_relation TR2({"D1", "D2", "D3"}, true, EmissionSpec("gaussian"),


### PR DESCRIPTION
The schema now differentiates between clean and noisy relations. The schema line for a noisy relation contains the name of its base relation.

I went for explicitness by prepending `"clean"` to all the lines of the existing schema files, even though it's a bit clunky. If anyone has an alternative they like better I'm happy to discuss and update this (though whatever we do for Model 4 I think will get clobbered by later models anyway).

Fixes #53