### PR TITLE
Remove EmissionVar's from the PCleanSchema

### DIFF
--- a/cxx/pclean/io_test.cc
+++ b/cxx/pclean/io_test.cc
@@ -10,23 +10,22 @@ BOOST_AUTO_TEST_CASE(test_read_schema) {
 # Hello!  This is my test schema string.  I hope you like it.
 class School
   name ~ bigram  # TODO: make this prefer school_names
-  degree_dist ~ categorical[num_classes=100]
+  degree_dist ~ categorical(num_classes=100)
 
 class Physician
   school ~ School
-  degree ~ stringcat[strings="MD PT NP DO PHD"]
-  specialty ~ stringcat[strings="Family Med:Internal Med:Physical Therapy", delim=":"]
-  observed_degree ~ maybe_swap(degree)  # TODO: handle p_err ~ beta(1, 1000)
+  degree ~ stringcat(strings="MD PT NP DO PHD")
+  specialty ~ stringcat(strings="Family Med:Internal Med:Physical Therapy", delim=":")
+  # observed_degree ~ maybe_swap(degree)  # TODO: handle p_err ~ beta(1, 1000)
 
 class City
   name ~ bigram
   # Gary Gulman has a good routine about how the states got their two letter
   # abbreviations.
-  state ~ strigcat[strings="AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY"]
+  state ~ strigcat(strings="AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY")
 
 class Practice # makes perfect!
   city ~ City
-  bad_city ~ bigram(city.name)
 
 class Record
   physician ~ Physician
@@ -36,7 +35,7 @@ observe
   physician.specialty as Specialty
   physician.school.name as School
   physician.observed_degree as Degree
-  location.bad_city as City
+  location.city.name as City
   location.city.state as State
   from Record
 )""");
@@ -58,18 +57,13 @@ observe
   BOOST_TEST(schema.classes[0].name == "School");
   BOOST_TEST(schema.classes[0].vars.size() == 2);
   BOOST_TEST(schema.classes[0].vars[0].name == "name");
-  BOOST_TEST(std::get<DistributionVar>(schema.classes[0].vars[0].spec).distribution_name == "bigram");
+  BOOST_TEST(std::get<ScalarVar>(schema.classes[0].vars[0].spec).joint_name == "bigram");
   BOOST_TEST(schema.classes[0].vars[1].name == "degree_dist");
-  BOOST_TEST(std::get<DistributionVar>(schema.classes[0].vars[1].spec).distribution_name == "categorical");
-  BOOST_TEST(std::get<DistributionVar>(schema.classes[0].vars[1].spec).distribution_params["num_classes"] == "100");
+  BOOST_TEST(std::get<ScalarVar>(schema.classes[0].vars[1].spec).joint_name == "categorical");
+  BOOST_TEST(std::get<ScalarVar>(schema.classes[0].vars[1].spec).params["num_classes"] == "100");
 
   BOOST_TEST(schema.classes[1].name == "Physician");
-  BOOST_TEST(schema.classes[1].vars.size() == 4);
+  BOOST_TEST(schema.classes[1].vars.size() == 3);
   BOOST_TEST(schema.classes[1].vars[0].name == "school");
   BOOST_TEST(std::get<ClassVar>(schema.classes[1].vars[0].spec).class_name == "School");
-  BOOST_TEST(schema.classes[1].vars[3].name == "observed_degree");
-  BOOST_TEST(std::get<EmissionVar>(schema.classes[1].vars[3].spec).emission_name == "maybe_swap");
-  std::vector<std::string> expected_path3 = {"degree"};
-  BOOST_TEST(std::get<EmissionVar>(schema.classes[1].vars[3].spec).field_path
-             == expected_path3, tt::per_element());
 }

--- a/cxx/pclean/schema.cc
+++ b/cxx/pclean/schema.cc
@@ -87,21 +87,12 @@ T_schema PCleanSchemaHelper::make_hirm_schema() {
   for (const auto& c : schema.classes) {
     for (const auto& v : c.vars) {
       std::string rel_name = c.name + ':' + v.name;
-      if (const DistributionVar* dv = std::get_if<DistributionVar>(&(v.spec))) {
+      if (const ScalarVar* dv = std::get_if<ScalarVar>(&(v.spec))) {
         T_clean_relation relation;
+        // TODO(thomaswc): Add code to resolve joint names and params
+        // into both a DistributionSpec and EmissionSpec.
         relation.distribution_spec = DistributionSpec(
-            dv->distribution_name, dv->distribution_params);
-        relation.is_observed = false;
-        relation.domains.push_back(c.name);
-        for (const std::string& sc : get_source_classes(c.name)) {
-          relation.domains.push_back(sc);
-        }
-        tschema[rel_name] = relation;
-      } else if (const EmissionVar *ev = std::get_if<EmissionVar>(&(v.spec))) {
-        T_noisy_relation relation;
-        relation.emission_spec = EmissionSpec(
-            ev->emission_name, ev->emission_params);
-        relation.base_relation = get_base_relation_name(c, ev->field_path);
+            dv->joint_name, dv->params);
         relation.is_observed = false;
         relation.domains.push_back(c.name);
         for (const std::string& sc : get_source_classes(c.name)) {

--- a/cxx/pclean/schema.hh
+++ b/cxx/pclean/schema.hh
@@ -11,20 +11,12 @@
 
 #include "irm.hh"
 
-struct DistributionVar {
-  std::string distribution_name;
-  std::map<std::string, std::string> distribution_params;
+struct ScalarVar {
+  // joint_name is the name for the joint distribution/emission combination.
+  std::string joint_name;
+  std::map<std::string, std::string> params;
 };
 
-
-struct EmissionVar {
-  std::string emission_name;
-  std::map<std::string, std::string> emission_params;
-  // Currently only length two field_paths of the form
-  // [name_of_ClassVar_in_this_class, name_of_variable_in_that_class]
-  // are supported.
-  std::vector<std::string> field_path;
-};
 
 struct ClassVar {
   std::string class_name;
@@ -32,7 +24,7 @@ struct ClassVar {
 
 struct PCleanVariable {
   std::string name;
-  std::variant<DistributionVar, EmissionVar, ClassVar> spec;
+  std::variant<ScalarVar, ClassVar> spec;
 };
 
 struct PCleanClass {
@@ -66,7 +58,7 @@ class PCleanSchemaHelper {
   PCleanClass get_class_by_name(const std::string& name);
 
   // The parent classes of a class are those that are referred to by a
-  // ClassVar or EmissionVar inside the class.
+  // ClassVar inside the class.
   std::set<std::string> get_parent_classes(const std::string& name);
   // The ancestors of a class are the transitive closure of the parent
   // relationship.

--- a/cxx/pclean/schema_test.cc
+++ b/cxx/pclean/schema_test.cc
@@ -11,21 +11,20 @@ struct SchemaTestFixture {
     std::stringstream ss(R"""(
 class School
   name ~ bigram
-  degree_dist ~ categorical[num_classes=100]
+  degree_dist ~ categorical(num_classes=100)
 
 class Physician
   school ~ School
-  degree ~ stringcat[strings="MD PT NP DO PHD"]
-  specialty ~ stringcat[strings="Family Med:Internal Med:Physical Therapy", delim=":"]
+  degree ~ stringcat(strings="MD PT NP DO PHD")
+  specialty ~ stringcat(strings="Family Med:Internal Med:Physical Therapy", delim=":")
   # observed_degree ~ maybe_swap(degree)
 
 class City
   name ~ bigram
-  state ~ stringcat[strings="AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY"]
+  state ~ stringcat(strings="AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY")
 
 class Practice
   city ~ City
-  bad_city ~ bigram(city.name)
 
 class Record
   physician ~ Physician
@@ -35,7 +34,7 @@ observe
   physician.specialty as Specialty
   physician.school.name as School
   physician.observed_degree as Degree
-  location.bad_city as City
+  location.city.name as City
   location.city.state as State
   from Record
 )""");
@@ -114,13 +113,6 @@ BOOST_AUTO_TEST_CASE(test_make_hirm_schmea) {
   BOOST_TEST(cr4.domains == expected_domains3);
 
   BOOST_TEST(tschema.contains("City:state"));
-
-  BOOST_TEST(tschema.contains("Practice:bad_city"));
-  T_noisy_relation nr = std::get<T_noisy_relation>(tschema["Practice:bad_city"]);
-  BOOST_TEST(!nr.is_observed);
-  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::bigram_string));
-  std::vector<std::string> expected_domains4 = {"Practice", "City"};
-  BOOST_TEST(nr.domains == expected_domains4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
As promised.  Also renames DistributionVar into ScalarVar.  The code to resolve joint distribution/emission names into Spec's for both of them, and the code to create the correct relations will be in forthcoming pull requests.