### PR TITLE
Add get_joint_relations; refactor schema into schema and schema_helper

### DIFF
--- a/cxx/pclean/BUILD
+++ b/cxx/pclean/BUILD
@@ -17,6 +17,26 @@ cc_test(
 )
 
 cc_library(
+    name = "get_joint_relations",
+    hdrs = ["get_joint_relations.hh"],
+    srcs = ["get_joint_relations.cc"],
+    deps = [
+        ":schema",
+        "//:clean_relation",
+        "//:noisy_relation",
+    ],
+)
+
+cc_test(
+    name = "get_joint_relations_test",
+    srcs = ["get_joint_relations_test.cc"],
+    deps = [
+        ":get_joint_relations",
+        "@boost//:test",
+    ],
+)
+
+cc_library(
     name = "io",
     hdrs = ["io.hh"],
     srcs = ["io.cc"],
@@ -41,6 +61,7 @@ cc_binary(
     deps = [
         ":io",
         ":schema",
+        ":schema_helper",
         "//:cxxopts",
         "//:hirm_lib",
         "//:inference",
@@ -50,18 +71,27 @@ cc_binary(
 cc_library(
     name = "schema",
     hdrs = ["schema.hh"],
-    srcs = ["schema.cc"],
+    deps = [],
+)
+
+cc_library(
+    name = "schema_helper",
+    hdrs = ["schema_helper.hh"],
+    srcs = ["schema_helper.cc"],
     deps = [
+        ":get_joint_relations",
+        ":schema",
         "//:irm",
     ],
 )
 
+
 cc_test(
-    name = "schema_test",
-    srcs = ["schema_test.cc"],
+    name = "schema_helper_test",
+    srcs = ["schema_helper_test.cc"],
     deps = [
         ":io",
-        ":schema",
+        ":schema_helper",
         "@boost//:test",
     ],
 )

--- a/cxx/pclean/get_joint_relations.cc
+++ b/cxx/pclean/get_joint_relations.cc
@@ -1,0 +1,50 @@
+#include "pclean/get_joint_relations.hh"
+
+#include <map>
+#include <string>
+#include <utility>
+
+#include "distributions/get_distribution.hh"
+#include "emissions/get_emission.hh"
+
+std::map<std::string, std::pair<std::string, std::string>> JOINT_NAME_TO_PARTS =
+{
+  // TODO(thomaswc): Implement an int emission function to use with the
+  // Skellam distribution.
+  {"bool", {"bernoulli", "sometimes_bitflip"}},
+  {"categorical", {"categorical", "sometimes_categorical"}},
+  {"real", {"normal", "sometimes_gaussian"}},
+  {"string", {"bigram", "bigram"}},
+  {"stringcat", {"stringcat", "bigram"}},
+  // TODO(thomaswc): Consider implementing an emission function to use with
+  // stringcat where the corrupted value is still a valid, in-category string.
+  // TODO(thomaswc): Consider implementing a pair for positive reals based
+  // on a log-normal distribution.
+};
+
+
+T_clean_relation get_distribution_relation(
+    const ScalarVar& scalar_var,
+    const std::vector<std::string>& domains) {
+  T_clean_relation cr;
+  cr.distribution_spec = DistributionSpec(
+      JOINT_NAME_TO_PARTS[scalar_var.joint_name].first,
+      scalar_var.params);
+  cr.is_observed = false;
+  cr.domains = domains;
+  return cr;
+}
+
+T_noisy_relation get_emission_relation(
+    const ScalarVar& scalar_var,
+    const std::vector<std::string>& domains,
+    const std::string& base_relation) {
+  T_noisy_relation nr;
+  nr.emission_spec = EmissionSpec(
+      JOINT_NAME_TO_PARTS[scalar_var.joint_name].second,
+      scalar_var.params);
+  nr.is_observed = false;
+  nr.domains = domains;
+  nr.base_relation = base_relation;
+  return nr;
+}

--- a/cxx/pclean/get_joint_relations.hh
+++ b/cxx/pclean/get_joint_relations.hh
@@ -11,7 +11,7 @@
 #include "pclean/schema.hh"
 
 // Given the joint_name and params in the ScalarVar, and a list of domains,
-// return a clean elation containing the generative distribution for the
+// return a clean relation containing the generative distribution for the
 // variable.
 T_clean_relation get_distribution_relation(
     const ScalarVar& scalar_var,

--- a/cxx/pclean/get_joint_relations.hh
+++ b/cxx/pclean/get_joint_relations.hh
@@ -1,0 +1,25 @@
+// Copyright 2024
+// See LICENSE.txt
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "clean_relation.hh"
+#include "noisy_relation.hh"
+#include "pclean/schema.hh"
+
+// Given the joint_name and params in the ScalarVar, and a list of domains,
+// return a clean elation containing the generative distribution for the
+// variable.
+T_clean_relation get_distribution_relation(
+    const ScalarVar& scalar_var,
+    const std::vector<std::string>& domains);
+
+// Given the joint_name and params in the ScalarVar, and a list of domains,
+// return a noisy relation containing the emission for the variable.
+T_noisy_relation get_emission_relation(
+    const ScalarVar& scalar_var,
+    const std::vector<std::string>& domains,
+    const std::string& base_relation);

--- a/cxx/pclean/get_joint_relations_test.cc
+++ b/cxx/pclean/get_joint_relations_test.cc
@@ -1,0 +1,90 @@
+#define BOOST_TEST_MODULE test pclean_get_joint_relations
+
+#include "pclean/get_joint_relations.hh"
+#include <boost/test/included/unit_test.hpp>
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(test_bool) {
+  ScalarVar sv;
+  sv.joint_name = "bool";
+  T_clean_relation cr = get_distribution_relation(sv, {"City", "College"});
+  BOOST_TEST(!cr.is_observed);
+  std::vector<std::string> expected_domains = {"City", "College"};
+  BOOST_TEST(cr.domains == expected_domains);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::bernoulli));
+
+  T_noisy_relation nr = get_emission_relation(sv, {"City", "College"}, "R1");
+  BOOST_TEST(!nr.is_observed);
+  BOOST_TEST(nr.domains == expected_domains);
+  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::sometimes_bitflip));
+  BOOST_TEST(nr.base_relation == "R1");
+}
+
+BOOST_AUTO_TEST_CASE(test_categorical) {
+  ScalarVar sv;
+  sv.joint_name = "categorical";
+  sv.params["k"] = "5";
+  T_clean_relation cr = get_distribution_relation(sv, {"Employer", "Country"});
+  BOOST_TEST(!cr.is_observed);
+  std::vector<std::string> expected_domains = {"Employer", "Country"};
+  BOOST_TEST(cr.domains == expected_domains);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::categorical));
+
+  T_noisy_relation nr = get_emission_relation(sv, {"Employer", "Country"}, "R2");
+  BOOST_TEST(!nr.is_observed);
+  BOOST_TEST(nr.domains == expected_domains);
+  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::sometimes_categorical));
+  BOOST_TEST(nr.base_relation == "R2");
+}
+
+BOOST_AUTO_TEST_CASE(test_real) {
+  ScalarVar sv;
+  sv.joint_name = "real";
+  T_clean_relation cr = get_distribution_relation(sv, {"Parent"});
+  BOOST_TEST(!cr.is_observed);
+  std::vector<std::string> expected_domains = {"Parent"};
+  BOOST_TEST(cr.domains == expected_domains);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::normal));
+
+  T_noisy_relation nr = get_emission_relation(sv, {"Parent"}, "R3");
+  BOOST_TEST(!nr.is_observed);
+  BOOST_TEST(nr.domains == expected_domains);
+  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::sometimes_gaussian));
+  BOOST_TEST(nr.base_relation == "R3");
+}
+
+BOOST_AUTO_TEST_CASE(test_string) {
+  ScalarVar sv;
+  sv.joint_name = "string";
+  T_clean_relation cr = get_distribution_relation(sv, {"Publisher", "City"});
+  BOOST_TEST(!cr.is_observed);
+  std::vector<std::string> expected_domains = {"Publisher", "City"};
+  BOOST_TEST(cr.domains == expected_domains);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::bigram));
+
+  T_noisy_relation nr = get_emission_relation(sv, {"Publisher", "City"}, "R4");
+  BOOST_TEST(!nr.is_observed);
+  BOOST_TEST(nr.domains == expected_domains);
+  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::bigram_string));
+  BOOST_TEST(nr.base_relation == "R4");
+}
+
+BOOST_AUTO_TEST_CASE(test_stringcat) {
+  ScalarVar sv;
+  sv.joint_name = "stringcat";
+  sv.params["strings"] = "radial bilateral asymmetric";
+  T_clean_relation cr = get_distribution_relation(
+      sv, {"Species", "Genus", "Family", "Order"});
+  BOOST_TEST(!cr.is_observed);
+  std::vector<std::string> expected_domains = {
+    "Species", "Genus", "Family", "Order"};
+  BOOST_TEST(cr.domains == expected_domains);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::stringcat));
+
+  T_noisy_relation nr = get_emission_relation(
+      sv, {"Species", "Genus", "Family", "Order"}, "R5");
+  BOOST_TEST(!nr.is_observed);
+  BOOST_TEST(nr.domains == expected_domains);
+  BOOST_TEST((nr.emission_spec.emission == EmissionEnum::bigram_string));
+  BOOST_TEST(nr.base_relation == "R5");
+}

--- a/cxx/pclean/pclean.cc
+++ b/cxx/pclean/pclean.cc
@@ -12,6 +12,7 @@
 #include "inference.hh"
 #include "pclean/io.hh"
 #include "pclean/schema.hh"
+#include "pclean/schema_helper.hh"
 
 int main(int argc, char** argv) {
   cxxopts::Options options(

--- a/cxx/pclean/schema.hh
+++ b/cxx/pclean/schema.hh
@@ -4,12 +4,9 @@
 #pragma once
 
 #include <map>
-#include <set>
 #include <string>
 #include <variant>
 #include <vector>
-
-#include "irm.hh"
 
 struct ScalarVar {
   // joint_name is the name for the joint distribution/emission combination.
@@ -48,32 +45,4 @@ struct PCleanQuery {
 struct PCleanSchema {
   std::vector<PCleanClass> classes;
   PCleanQuery query;
-};
-
-// A class for quickly computing various properties of the schema.
-class PCleanSchemaHelper {
- public:
-  PCleanSchemaHelper(const PCleanSchema& s);
-
-  PCleanClass get_class_by_name(const std::string& name);
-
-  // The parent classes of a class are those that are referred to by a
-  // ClassVar inside the class.
-  std::set<std::string> get_parent_classes(const std::string& name);
-  // The ancestors of a class are the transitive closure of the parent
-  // relationship.
-  std::set<std::string> get_ancestor_classes(const std::string& name);
-  // The source classes of a class are its ancestors without parents.
-  std::set<std::string> get_source_classes(const std::string& name);
-
-  T_schema make_hirm_schema();
-
- private:
-  void compute_class_name_cache();
-  void compute_ancestors_cache();
-  std::set<std::string> compute_ancestors_for(const std::string& name);
-
-  PCleanSchema schema;
-  std::map<std::string, int> class_name_to_index;
-  std::map<std::string, std::set<std::string>> ancestors;
 };

--- a/cxx/pclean/schema_helper.cc
+++ b/cxx/pclean/schema_helper.cc
@@ -55,18 +55,6 @@ std::set<std::string> PCleanSchemaHelper::get_ancestor_classes(
   return ancestors[name];
 }
 
-std::set<std::string> PCleanSchemaHelper::get_source_classes(
-    const std::string& name) {
-  std::set<std::string> sources;
-  for (const std::string& c: ancestors[name]) {
-    const std::set<std::string>& parents = get_parent_classes(c);
-    if (parents.empty()) {
-      sources.insert(c);
-    }
-  }
-  return sources;
-}
-
 std::string get_base_relation_name(
     const PCleanClass& c, const std::vector<std::string>& field_path) {
   assert(field_path.size() == 2);

--- a/cxx/pclean/schema_helper.cc
+++ b/cxx/pclean/schema_helper.cc
@@ -91,7 +91,7 @@ T_schema PCleanSchemaHelper::make_hirm_schema() {
       if (const ScalarVar* dv = std::get_if<ScalarVar>(&(v.spec))) {
         std::vector<std::string> domains;
         domains.push_back(c.name);
-        for (const std::string& sc : get_source_classes(c.name)) {
+        for (const std::string& sc : get_ancestor_classes(c.name)) {
           domains.push_back(sc);
         }
         tschema[rel_name] = get_distribution_relation(*dv, domains);

--- a/cxx/pclean/schema_helper.hh
+++ b/cxx/pclean/schema_helper.hh
@@ -1,0 +1,39 @@
+// Copyright 2024
+// See LICENSE.txt
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "irm.hh"
+#include "pclean/schema.hh"
+
+// A class for quickly computing various properties of the schema.
+class PCleanSchemaHelper {
+ public:
+  PCleanSchemaHelper(const PCleanSchema& s);
+
+  PCleanClass get_class_by_name(const std::string& name);
+
+  // The parent classes of a class are those that are referred to by a
+  // ClassVar inside the class.
+  std::set<std::string> get_parent_classes(const std::string& name);
+  // The ancestors of a class are the transitive closure of the parent
+  // relationship.
+  std::set<std::string> get_ancestor_classes(const std::string& name);
+  // The source classes of a class are its ancestors without parents.
+  std::set<std::string> get_source_classes(const std::string& name);
+
+  T_schema make_hirm_schema();
+
+ private:
+  void compute_class_name_cache();
+  void compute_ancestors_cache();
+  std::set<std::string> compute_ancestors_for(const std::string& name);
+
+  PCleanSchema schema;
+  std::map<std::string, int> class_name_to_index;
+  std::map<std::string, std::set<std::string>> ancestors;
+};

--- a/cxx/pclean/schema_helper_test.cc
+++ b/cxx/pclean/schema_helper_test.cc
@@ -1,0 +1,118 @@
+#define BOOST_TEST_MODULE test pclean_schema
+
+#include "pclean/io.hh"
+#include "pclean/schema_helper.hh"
+#include <sstream>
+#include <boost/test/included/unit_test.hpp>
+namespace tt = boost::test_tools;
+
+struct SchemaTestFixture {
+  SchemaTestFixture() {
+    std::stringstream ss(R"""(
+class School
+  name ~ string
+  degree_dist ~ categorical(k=100)
+
+class Physician
+  school ~ School
+  degree ~ stringcat(strings="MD PT NP DO PHD")
+  specialty ~ stringcat(strings="Family Med:Internal Med:Physical Therapy", delim=":")
+  # observed_degree ~ maybe_swap(degree)
+
+class City
+  name ~ string
+  state ~ stringcat(strings="AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY")
+
+class Practice
+  city ~ City
+
+class Record
+  physician ~ Physician
+  location ~ Practice
+
+observe
+  physician.specialty as Specialty
+  physician.school.name as School
+  physician.observed_degree as Degree
+  location.city.name as City
+  location.city.state as State
+  from Record
+)""");
+    assert(read_schema(ss, &schema));
+  }
+
+  ~SchemaTestFixture() {}
+
+  PCleanSchema schema;
+};
+
+BOOST_FIXTURE_TEST_SUITE(schema_test_suite, SchemaTestFixture)
+
+BOOST_AUTO_TEST_CASE(test_get_class_by_name) {
+  PCleanSchemaHelper schema_helper(schema);
+  PCleanClass c = schema_helper.get_class_by_name("Practice");
+  BOOST_TEST(c.name == "Practice");
+}
+
+BOOST_AUTO_TEST_CASE(test_get_parent_classes) {
+  PCleanSchemaHelper schema_helper(schema);
+  BOOST_TEST(schema_helper.get_parent_classes("School").empty());
+  BOOST_TEST(schema_helper.get_parent_classes("City").empty());
+  BOOST_TEST(schema_helper.get_parent_classes("Physician").size() == 1);
+  BOOST_TEST(schema_helper.get_parent_classes("Practice").size() == 1);
+  BOOST_TEST(schema_helper.get_parent_classes("Record").size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_ancestor_classes) {
+  PCleanSchemaHelper schema_helper(schema);
+  BOOST_TEST(schema_helper.get_ancestor_classes("School").empty());
+  BOOST_TEST(schema_helper.get_ancestor_classes("City").empty());
+  BOOST_TEST(schema_helper.get_ancestor_classes("Physician").size() == 1);
+  BOOST_TEST(schema_helper.get_ancestor_classes("Practice").size() == 1);
+  BOOST_TEST(schema_helper.get_ancestor_classes("Record").size() == 4);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_source_classes) {
+  PCleanSchemaHelper schema_helper(schema);
+  BOOST_TEST(schema_helper.get_source_classes("School").empty());
+  BOOST_TEST(schema_helper.get_source_classes("City").empty());
+  BOOST_TEST(schema_helper.get_source_classes("Physician").size() == 1);
+  BOOST_TEST(schema_helper.get_source_classes("Practice").size() == 1);
+  BOOST_TEST(schema_helper.get_source_classes("Record").size() == 2);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_make_hirm_schmea) {
+  PCleanSchemaHelper schema_helper(schema);
+  T_schema tschema = schema_helper.make_hirm_schema();
+
+  BOOST_TEST(tschema.contains("School:name"));
+  T_clean_relation cr = std::get<T_clean_relation>(tschema["School:name"]);
+  BOOST_TEST(!cr.is_observed);
+  BOOST_TEST((cr.distribution_spec.distribution == DistributionEnum::bigram));
+  std::vector<std::string> expected_domains = {"School"};
+  BOOST_TEST(cr.domains == expected_domains);
+
+  BOOST_TEST(tschema.contains("School:degree_dist"));
+  T_clean_relation cr2 = std::get<T_clean_relation>(tschema["School:degree_dist"]);
+  BOOST_TEST((cr2.distribution_spec.distribution == DistributionEnum::categorical));
+  BOOST_TEST(cr2.distribution_spec.distribution_args.contains("k"));
+  BOOST_TEST(cr2.domains == expected_domains);
+
+  BOOST_TEST(tschema.contains("Physician:degree"));
+  T_clean_relation cr3 = std::get<T_clean_relation>(tschema["Physician:degree"]);
+  BOOST_TEST((cr3.distribution_spec.distribution == DistributionEnum::stringcat));
+  std::vector<std::string> expected_domains2 = {"Physician", "School"};
+  BOOST_TEST(cr3.domains == expected_domains2);
+
+  BOOST_TEST(tschema.contains("Physician:specialty"));
+
+  BOOST_TEST(tschema.contains("City:name"));
+  T_clean_relation cr4 = std::get<T_clean_relation>(tschema["City:name"]);
+  std::vector<std::string> expected_domains3 = {"City"};
+  BOOST_TEST(cr4.domains == expected_domains3);
+
+  BOOST_TEST(tschema.contains("City:state"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/cxx/pclean/schema_helper_test.cc
+++ b/cxx/pclean/schema_helper_test.cc
@@ -72,16 +72,6 @@ BOOST_AUTO_TEST_CASE(test_get_ancestor_classes) {
   BOOST_TEST(schema_helper.get_ancestor_classes("Record").size() == 4);
 }
 
-BOOST_AUTO_TEST_CASE(test_get_source_classes) {
-  PCleanSchemaHelper schema_helper(schema);
-  BOOST_TEST(schema_helper.get_source_classes("School").empty());
-  BOOST_TEST(schema_helper.get_source_classes("City").empty());
-  BOOST_TEST(schema_helper.get_source_classes("Physician").size() == 1);
-  BOOST_TEST(schema_helper.get_source_classes("Practice").size() == 1);
-  BOOST_TEST(schema_helper.get_source_classes("Record").size() == 2);
-}
-
-
 BOOST_AUTO_TEST_CASE(test_make_hirm_schmea) {
   PCleanSchemaHelper schema_helper(schema);
   T_schema tschema = schema_helper.make_hirm_schema();


### PR DESCRIPTION
The refactoring was necessary to avoid a circular BUILD dependency between schema and get_joint_relations.  (Another reason to keep the PCleanSchema and PCleanSchemaHelper classes separate!)