### PR TITLE
Restore distributions/adapter; add typo_int and typo_real joint relations

### DIFF
--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -21,14 +21,14 @@ cc_library(
 )
 
 cc_library(
-￼    name = "adapter",
-￼    hdrs = ["adapter.hh"],
-￼    visibility = ["//:__subpackages__"],
-￼    deps = [
-￼        ":base",
-￼    ],
+    name = "adapter",
+    hdrs = ["adapter.hh"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":base",
+    ],
 )
-￼
+
 cc_library(
     name = "base",
     hdrs = ["base.hh"],
@@ -131,14 +131,14 @@ cc_library(
 )
 
 cc_test(
-￼    name = "adapter_test",
-￼    srcs = ["adapter_test.cc"],
-￼    deps = [
-￼        ":adapter",
-￼        ":normal",
-￼        "@boost//:algorithm",
-￼        "@boost//:test",
-￼    ],
+    name = "adapter_test",
+    srcs = ["adapter_test.cc"],
+    deps = [
+        ":adapter",
+        ":normal",
+        "@boost//:algorithm",
+        "@boost//:test",
+    ],
 )
 
 cc_test(

--- a/cxx/distributions/BUILD
+++ b/cxx/distributions/BUILD
@@ -6,6 +6,7 @@ cc_library(
     srcs = ["get_distribution.cc"],
     visibility = ["//:__subpackages__"],
     deps = [
+        ":adapter",
         ":base",
         ":beta_bernoulli",
         ":bigram",
@@ -19,6 +20,15 @@ cc_library(
     ],
 )
 
+cc_library(
+￼    name = "adapter",
+￼    hdrs = ["adapter.hh"],
+￼    visibility = ["//:__subpackages__"],
+￼    deps = [
+￼        ":base",
+￼    ],
+)
+￼
 cc_library(
     name = "base",
     hdrs = ["base.hh"],
@@ -118,6 +128,17 @@ cc_library(
         ":base",
         "//:util_math",
     ],
+)
+
+cc_test(
+￼    name = "adapter_test",
+￼    srcs = ["adapter_test.cc"],
+￼    deps = [
+￼        ":adapter",
+￼        ":normal",
+￼        "@boost//:algorithm",
+￼        "@boost//:test",
+￼    ],
 )
 
 cc_test(

--- a/cxx/distributions/adapter.hh
+++ b/cxx/distributions/adapter.hh
@@ -45,12 +45,14 @@ class DistributionAdapter : public Distribution<std::string> {
 
   double logp_score() const { return d->logp_score(); }
 
-  std::string sample() {
-    S s = d->sample();
+  std::string sample(std::mt19937* prng) {
+    S s = d->sample(prng);
     return to_string(s);
   }
 
-  void transition_hyperparameters() { d->transition_hyperparameters(); }
+  void transition_hyperparameters(std::mt19937* prng) {
+    d->transition_hyperparameters(prng);
+  }
 
   void init_theta(std::mt19937* prng) { d->init_theta(prng); }
   void transition_theta(std::mt19937* prng) { d->transition_theta(prng); }

--- a/cxx/distributions/adapter.hh
+++ b/cxx/distributions/adapter.hh
@@ -1,0 +1,59 @@
+// Copyright 2024
+// See LICENSE.txt
+
+// A class for turning Distribution<SampleType>'s into
+// Distribution<string>'s.
+
+#pragma once
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "distributions/base.hh"
+
+template <typename S = double>
+class DistributionAdapter : public Distribution<std::string> {
+ public:
+  // The underlying distribution that is being adapted.  We own the
+  // underlying Distribution.
+  Distribution<S>* d;
+
+  DistributionAdapter(Distribution<S>* dd) : d(dd) {};
+
+  S from_string(const std::string& x) const {
+    S s;
+    std::istringstream(x) >> s;
+    return s;
+  }
+
+  std::string to_string(const S& s) const {
+    std::ostringstream os;
+    os << s;
+    return os.str();
+  }
+
+  void incorporate(const std::string& x, double weight = 1.0) {
+    S s = from_string(x);
+    N += weight;
+    d->incorporate(s, weight);
+  }
+
+  double logp(const std::string& x) const {
+    S s = from_string(x);
+    return d->logp(s);
+  }
+
+  double logp_score() const { return d->logp_score(); }
+
+  std::string sample() {
+    S s = d->sample();
+    return to_string(s);
+  }
+
+  void transition_hyperparameters() { d->transition_hyperparameters(); }
+
+  void init_theta(std::mt19937* prng) { d->init_theta(prng); }
+  void transition_theta(std::mt19937* prng) { d->transition_theta(prng); }
+
+  ~DistributionAdapter() { delete d; }
+};

--- a/cxx/distributions/adapter_test.cc
+++ b/cxx/distributions/adapter_test.cc
@@ -28,6 +28,7 @@ BOOST_AUTO_TEST_CASE(adapt_normal) {
   BOOST_TEST(ad.logp("6.0") == n->logp(6.), tt::tolerance(1e-6));
   BOOST_TEST(ad.logp_score() == n->logp_score(), tt::tolerance(1e-6));
 
-  std::string samp = ad.sample();
+  std::mt19937 prng;
+  std::string samp = ad.sample(&prng);
 }
 

--- a/cxx/distributions/adapter_test.cc
+++ b/cxx/distributions/adapter_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2024
+// Refer to LICENSE.txt
+
+#define BOOST_TEST_MODULE test Normal
+
+#include "distributions/adapter.hh"
+
+#include <boost/test/included/unit_test.hpp>
+
+#include "distributions/normal.hh"
+namespace tt = boost::test_tools;
+
+BOOST_AUTO_TEST_CASE(adapt_normal) {
+  Normal* n = new Normal;
+  DistributionAdapter<double> ad(n);
+
+  ad.incorporate("5.0");
+  ad.incorporate("-2.0");
+  BOOST_TEST(n->N == ad.N);
+
+  ad.unincorporate("5.0");
+  ad.incorporate("7.0");
+  BOOST_TEST(n->N == ad.N);
+
+  ad.unincorporate("-2.0");
+  BOOST_TEST(n->N == ad.N);
+
+  BOOST_TEST(ad.logp("6.0") == n->logp(6.), tt::tolerance(1e-6));
+  BOOST_TEST(ad.logp_score() == n->logp_score(), tt::tolerance(1e-6));
+
+  std::string samp = ad.sample();
+}
+

--- a/cxx/distributions/get_distribution.cc
+++ b/cxx/distributions/get_distribution.cc
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <sstream>
 
+#include "distributions/adapter.hh"
 #include "distributions/beta_bernoulli.hh"
 #include "distributions/bigram.hh"
 #include "distributions/dirichlet_categorical.hh"
@@ -53,6 +54,12 @@ DistributionSpec::DistributionSpec(
   } else if (dist_name == "stringcat") {
     distribution = DistributionEnum::stringcat;
     observation_type = ObservationEnum::string_type;
+  } else if (dist_name == "string_normal") {
+    distribution = DistributionEnum::string_normal;
+    observation_type = ObservationEnum::string_type;
+  } else if (dist_name == "string_skellam") {
+    distribution = DistributionEnum::string_skellam;
+    observation_type = ObservationEnum::string_type;
   } else {
     assert(false && "Unsupported distribution name.");
   }
@@ -88,6 +95,13 @@ DistributionVariant get_prior(const DistributionSpec& spec,
       boost::split(strings, spec.distribution_args.at("strings"),
                    boost::is_any_of(delim));
       return new StringCat(strings);
+    }
+    case DistributionEnum::string_normal:
+      return new DistributionAdapter<double>(new Normal);
+    case DistributionEnum::string_skellam: {
+      Skellam* s = new Skellam;
+      s->init_theta(prng);
+      return new DistributionAdapter<int>(s);
     }
     default:
       assert(false && "Unsupported distribution enum value.");

--- a/cxx/distributions/get_distribution.hh
+++ b/cxx/distributions/get_distribution.hh
@@ -21,7 +21,9 @@ enum class DistributionEnum {
   categorical,
   normal,
   skellam,
-  stringcat
+  stringcat,
+  string_skellam,
+  string_normal
 };
 
 struct DistributionSpec {

--- a/cxx/distributions/get_distribution_test.cc
+++ b/cxx/distributions/get_distribution_test.cc
@@ -51,6 +51,14 @@ BOOST_AUTO_TEST_CASE(test_distribution_spec) {
   BOOST_TEST((dsc2.distribution == DistributionEnum::stringcat));
   BOOST_TEST((dsc2.distribution_args.size() == 2));
   BOOST_CHECK_EQUAL(dsc2.distribution_args.at("strings"), "yes:no");
+
+  DistributionSpec dsn = DistributionSpec("string_normal");
+  BOOST_TEST((dsn.distribution == DistributionEnum::string_normal));
+  BOOST_TEST(dsn.distribution_args.empty());
+
+  DistributionSpec dss = DistributionSpec("string_skellam");
+  BOOST_TEST((dss.distribution == DistributionEnum::string_skellam));
+  BOOST_TEST(dss.distribution_args.empty());
 }
 
 BOOST_AUTO_TEST_CASE(test_get_prior_bernoulli) {
@@ -109,4 +117,22 @@ BOOST_AUTO_TEST_CASE(test_get_prior_stringcat) {
   Distribution<std::string> *d = std::get<Distribution<std::string>*>(dv);
   std::string name = typeid(*d).name();
   BOOST_TEST(name.find("StringCat") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_prior_string_normal) {
+  std::mt19937 prng;
+
+  DistributionVariant dv = get_prior(DistributionSpec("string_normal"), &prng);
+  Distribution<std::string> *d = std::get<Distribution<std::string>*>(dv);
+  std::string name = typeid(*d).name();
+  BOOST_TEST(name.find("DistributionAdapter") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_prior_string_skellam) {
+  std::mt19937 prng;
+
+  DistributionVariant dv = get_prior(DistributionSpec("string_skellam"), &prng);
+  Distribution<std::string> *d = std::get<Distribution<std::string>*>(dv);
+  std::string name = typeid(*d).name();
+  BOOST_TEST(name.find("DistributionAdapter") != std::string::npos);
 }

--- a/cxx/pclean/get_joint_relations.cc
+++ b/cxx/pclean/get_joint_relations.cc
@@ -16,6 +16,8 @@ std::map<std::string, std::pair<std::string, std::string>> JOINT_NAME_TO_PARTS =
   {"real", {"normal", "sometimes_gaussian"}},
   {"string", {"bigram", "bigram"}},
   {"stringcat", {"stringcat", "bigram"}},
+  {"typo_int", {"string_skellam", "bigram"}},
+  {"typo_real", {"string_normal", "bigram"}},
   // TODO(thomaswc): Consider implementing an emission function to use with
   // stringcat where the corrupted value is still a valid, in-category string.
   // TODO(thomaswc): Consider implementing a pair for positive reals based


### PR DESCRIPTION
When adding the new PClean schemas in https://github.com/probcomp/hierarchical-irm/pull/132, the need came up for joint relations that covered "numbers corrupted by typos", such as a zip code field that might contain "1003x".

This pull request addresses that need.