### PR TITLE
Enable fast string alignments even with bad edit distances

### DIFF
--- a/cxx/emissions/string_alignment.cc
+++ b/cxx/emissions/string_alignment.cc
@@ -33,8 +33,6 @@ void topk_alignments(int k, const std::string& s1, const std::string& s2,
 
     // Does this alignment reach the end of both strings?  If so, ship it.
     double old_cost = -heap_top.cost;
-    printf("pos1 %ld pos2 %ld cost %f\n", heap_top.s1_position,
-           heap_top.s2_position, old_cost);
     if (std::cmp_equal(heap_top.s1_position, s1.length())
         && std::cmp_equal(heap_top.s2_position, s2.length())) {
       heap_top.cost = old_cost;

--- a/cxx/emissions/string_alignment.cc
+++ b/cxx/emissions/string_alignment.cc
@@ -1,3 +1,4 @@
+#include <map>
 #include <utility>
 #include "emissions/string_alignment.hh"
 
@@ -5,6 +6,8 @@ void topk_alignments(int k, const std::string& s1, const std::string& s2,
                      CostFunction cost_function,
                      std::vector<StrAlignment>* alignments) {
   std::vector<StrAlignment> heap;
+  std::map<std::pair<size_t, size_t>, int> visited;
+
   StrAlignment empty_alignment;
   empty_alignment.cost = -0.0;  // We negate all costs on the heap so that
                                 // the front of the heap is the min cost
@@ -21,8 +24,17 @@ void topk_alignments(int k, const std::string& s1, const std::string& s2,
     std::pop_heap(heap.begin(), heap.end());
     heap.pop_back();
 
+    std::pair<size_t, size_t> here = std::make_pair(
+        heap_top.s1_position, heap_top.s2_position);
+    int visit_count = ++(visited[here]);
+    if (visit_count > k) {
+      continue;
+    }
+
     // Does this alignment reach the end of both strings?  If so, ship it.
     double old_cost = -heap_top.cost;
+    printf("pos1 %ld pos2 %ld cost %f\n", heap_top.s1_position,
+           heap_top.s2_position, old_cost);
     if (std::cmp_equal(heap_top.s1_position, s1.length())
         && std::cmp_equal(heap_top.s2_position, s2.length())) {
       heap_top.cost = old_cost;

--- a/cxx/emissions/string_alignment_test.cc
+++ b/cxx/emissions/string_alignment_test.cc
@@ -81,3 +81,24 @@ BOOST_AUTO_TEST_CASE(test_custom_edit_distance) {
   BOOST_TEST(alignments[0].cost == 7);  // 2 deletions, 3 substitutions
 }
 
+double bad_edit_distance(const StrAlignment& alignment, double old_cost) {
+  const AlignPiece& p = alignment.align_pieces.back();
+  switch(p.index()) {
+    case 3: // Match
+      return old_cost + 3;
+    case 2: // Substitution
+      return old_cost + 2;
+    default: // Insertion or Deletion
+      return old_cost + 1;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(test_long_strings_and_bad_distance) {
+  std::vector<StrAlignment> alignments;
+  topk_alignments(
+      10,
+      "this is the theme to garry's show // the opening theme to garry's show",
+      "this is the music that you hear while they play the credits",
+      bad_edit_distance, &alignments);
+  BOOST_TEST(alignments.size() == 10);
+}


### PR DESCRIPTION
Fixes https://github.com/probcomp/hierarchical-irm/issues/142