### PR TITLE
Add IdentityEmission

### DIFF
--- a/cxx/emissions/BUILD
+++ b/cxx/emissions/BUILD
@@ -78,6 +78,15 @@ cc_library(
 )
 
 cc_library(
+    name = "identity",
+    hdrs = ["identity.hh"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":base",
+    ],
+)
+
+cc_library(
     name = "simple_string",
     srcs = ["simple_string.hh"],
     visibility = ["//:__subpackages__"],
@@ -150,6 +159,16 @@ cc_test(
     srcs = ["gaussian_test.cc"],
     deps = [
         ":gaussian",
+        "@boost//:algorithm",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "identity_test",
+    srcs = ["identity_test.cc"],
+    deps = [
+        ":identity",
         "@boost//:algorithm",
         "@boost//:test",
     ],

--- a/cxx/emissions/identity.hh
+++ b/cxx/emissions/identity.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "emissions/base.hh"
+
+// An Emission class where dirty always equals clean.
+template <typename SampleType = double>
+class IdentityEmission : public Emission<SampleType> {
+ public:
+  IdentityEmission() {}
+  ~IdentityEmission() {}
+
+  void incorporate(const std::pair<SampleType, SampleType>& x,
+                   double weight = 1.0) {
+    this->N += weight;
+  }
+
+  double logp(const std::pair<SampleType, SampleType>& x) const {
+    return 0.0;
+  }
+
+  double logp_score() const { return 0.0; }
+
+  void transition_hyperparameters(std::mt19937* prng) {}
+
+  SampleType sample_corrupted(const SampleType& clean, std::mt19937* prng) {
+    return clean;
+  }
+
+  SampleType propose_clean(const std::vector<SampleType>& corrupted,
+                           std::mt19937* prng) {
+    return corrupted[0];
+  }
+};

--- a/cxx/emissions/identity_test.cc
+++ b/cxx/emissions/identity_test.cc
@@ -1,0 +1,31 @@
+// Apache License, Version 2.0, refer to LICENSE.txt
+
+#define BOOST_TEST_MODULE test Identity
+
+#include "emissions/identity.hh"
+
+#include <boost/test/included/unit_test.hpp>
+#include <random>
+
+BOOST_AUTO_TEST_CASE(test_simple) {
+  IdentityEmission<bool> ie;
+
+  BOOST_TEST(ie.logp_score() == 0.0);
+  BOOST_TEST(ie.N == 0);
+  ie.incorporate(std::make_pair<bool, bool>(true, false));
+  BOOST_TEST(ie.logp_score() == 0.0);
+  BOOST_TEST(ie.N == 1);
+  ie.unincorporate(std::make_pair<bool, bool>(true, false));
+  BOOST_TEST(ie.logp_score() == 0.0);
+  BOOST_TEST(ie.N == 0);
+
+  ie.incorporate(std::make_pair<bool, bool>(false, true));
+  ie.incorporate(std::make_pair<bool, bool>(false, true));
+  BOOST_TEST(ie.logp_score() == 0.0);
+  BOOST_TEST(ie.N == 2);
+
+  BOOST_TEST(ie.logp(std::make_pair<bool, bool>(true, false)) == 0.0);
+
+  std::mt19937 prng;
+  BOOST_TEST(ie.propose_clean({true, true}, &prng));
+}


### PR DESCRIPTION
I'm planning to add an option to the pclean program where the user can specify if they want observations of the observe class to be treated as noisy or not.  This class will be used to support the "or not" option.