### PR TITLE
Add a sampling method to HIRM.

### DIFF
--- a/cxx/clean_relation_test.cc
+++ b/cxx/clean_relation_test.cc
@@ -192,3 +192,16 @@ BOOST_AUTO_TEST_CASE(test_from_string) {
   std::string s = R2.from_string("hello world");
   BOOST_TEST(s == "hello world");
 }
+
+BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
+  std::mt19937 prng;
+  Domain D1("D1");
+  Domain D2("D2");
+  DistributionSpec spec("normal");
+  CleanRelation<double> R1("R1", spec, {&D1, &D2});
+  R1.incorporate_sample(&prng, {0, 1});
+  R1.incorporate_sample(&prng, {0, 2});
+  R1.incorporate_sample(&prng, {5, 2});
+
+  BOOST_TEST(R1.data.size() == 3);
+}

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -336,11 +336,6 @@ void HIRM::sample_and_incorporate_relation(std::mt19937* prng,
              get_relation(r));
 }
 
-// Samples `n` values from each leaf relation (i.e. each relation that is not
-// the base relation of a different relation). Recursively samples some number
-// of values from non-leaf relations as needed to get to `n` leaf samples.
-// Beware: since `n` unique values are sampled from CRPs, if `n` is too high
-// relative to the CRP `alpha`s, this function might take a very long time.
 void HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
   std::map<std::string, CRP> domain_crps;
   for (const auto& [r, spec] : schema) {

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -8,10 +8,10 @@
 #include <unordered_set>
 #include <variant>
 
+#include "distributions/get_distribution.hh"
 #include "irm.hh"
 #include "relation.hh"
 #include "transition_latent_value.hh"
-#include "distributions/get_distribution.hh"
 
 class HIRM {
  public:
@@ -64,6 +64,8 @@ class HIRM {
       std::mt19937* prng);
 
   double logp_score() const;
+
+  void sample_and_incorporate(std::mt19937* prng, int n);
 
   ~HIRM();
 

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -65,8 +65,16 @@ class HIRM {
 
   double logp_score() const;
 
+  // Samples `n` values from each leaf relation (i.e. each relation that is not
+  // the base relation of a different relation). Recursively samples some number
+  // of values from non-leaf relations as needed to get to `n` leaf samples.
+  // Beware: since `n` unique values are sampled from CRPs, if `n` is too high
+  // relative to the CRP `alpha`s, this function might take a very long time.
   void sample_and_incorporate(std::mt19937* prng, int n);
 
+  // Incorporates a sample into relation `r`. If `r` is a noisy relation, this
+  // function recursively incorporates a sample into the base relation, if
+  // necessary.
   void sample_and_incorporate_relation(std::mt19937* prng, const std::string& r,
                                        T_items& items);
 

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -67,6 +67,9 @@ class HIRM {
 
   void sample_and_incorporate(std::mt19937* prng, int n);
 
+  void sample_and_incorporate_relation(std::mt19937* prng, const std::string& r,
+                                       T_items& items);
+
   ~HIRM();
 
   // Disable copying.

--- a/cxx/noisy_relation.hh
+++ b/cxx/noisy_relation.hh
@@ -70,10 +70,6 @@ class NoisyRelation : public Relation<T> {
 
   void incorporate_sample(std::mt19937* prng, const T_items& items) {
     T_items z = emission_relation.incorporate_items(prng, items);
-    T_items base_items = get_base_items(items);
-    if (!base_relation->get_data().contains(base_items)) {
-      base_relation->incorporate_sample(prng, base_items);
-    }
     const ValueType& base_val = get_base_value(items);
     ValueType value = sample_at_items(prng, items);
     data[items] = value;

--- a/cxx/noisy_relation.hh
+++ b/cxx/noisy_relation.hh
@@ -9,12 +9,12 @@
 #include <vector>
 
 #include "clean_relation.hh"
+#include "distributions/get_distribution.hh"
 #include "domain.hh"
+#include "emissions/base.hh"
 #include "relation.hh"
 #include "util_hash.hh"
 #include "util_math.hh"
-#include "distributions/get_distribution.hh"
-#include "emissions/base.hh"
 
 // T_noisy_relation is the text we get from reading a line of the schema file;
 // NoisyRelation is the object that does the work.
@@ -66,6 +66,19 @@ class NoisyRelation : public Relation<T> {
     emission_relation.incorporate(prng, items, std::make_pair(base_val, value));
     data[items] = value;
     base_to_noisy_items[base_items].insert(items);
+  }
+
+  void incorporate_sample(std::mt19937* prng, const T_items& items) {
+    T_items z = emission_relation.incorporate_items(prng, items);
+    T_items base_items = get_base_items(items);
+    if (!base_relation->get_data().contains(base_items)) {
+      base_relation->incorporate_sample(prng, base_items);
+    }
+    const ValueType& base_val = get_base_value(items);
+    ValueType value = sample_at_items(prng, items);
+    data[items] = value;
+    emission_relation.clusters.at(z)->incorporate(
+        std::make_pair(base_val, value));
   }
 
   // incorporate_to_cluster and unincorporate_from_cluster should be used with
@@ -186,7 +199,6 @@ class NoisyRelation : public Relation<T> {
   }
 
   ValueType sample_at_items(std::mt19937* prng, const T_items& items) const {
-    // TODO(emilyaf): Maybe take a sample if there is no base value.
     const ValueType& base_value = get_base_value(items);
     if (emission_relation.clusters.contains(items)) {
       return reinterpret_cast<Emission<ValueType>*>(

--- a/cxx/noisy_relation_test.cc
+++ b/cxx/noisy_relation_test.cc
@@ -190,3 +190,23 @@ BOOST_AUTO_TEST_CASE(test_cluster_logp_sample) {
   double lp = NR1.cluster_or_prior_logp(&prng, {0, 1, 2}, sample);
   BOOST_TEST(lp < 0.0);
 }
+
+BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
+  std::mt19937 prng;
+  Domain D1("D1");
+  Domain D2("D2");
+  Domain D3("D3");
+  DistributionSpec spec("normal");
+  CleanRelation<double> R1("R1", spec, {&D1, &D2});
+  R1.incorporate(&prng, {0, 1}, 3.);
+
+  EmissionSpec em_spec("sometimes_gaussian");
+  NoisyRelation<double> NR1("NR1", em_spec, {&D1, &D2, &D3}, &R1);
+
+  NR1.incorporate_sample(&prng, {0, 1, 1});
+  NR1.incorporate_sample(&prng, {0, 1, 5});
+  NR1.incorporate_sample(&prng, {0, 1, 2});
+
+  BOOST_TEST(NR1.data.size() == 3);
+  BOOST_TEST(R1.data.size() == 1);
+}

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -9,9 +9,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "distributions/get_distribution.hh"
 #include "domain.hh"
 #include "util_hash.hh"
-#include "distributions/get_distribution.hh"
 
 typedef std::vector<T_item> T_items;
 typedef VectorIntHash H_items;
@@ -21,44 +21,58 @@ class Relation {
  public:
   typedef T ValueType;
 
-  virtual void incorporate(std::mt19937* prng, const T_items& items, ValueType value) = 0;
+  virtual void incorporate(std::mt19937* prng, const T_items& items,
+                           ValueType value) = 0;
 
   virtual void unincorporate(const T_items& items) = 0;
 
-  virtual double logp(const T_items& items, ValueType value, std::mt19937* prng) = 0;
+  virtual double logp(const T_items& items, ValueType value,
+                      std::mt19937* prng) = 0;
 
   virtual double logp_score() const = 0;
 
-  virtual double cluster_or_prior_logp(std::mt19937* prng, const T_items& items, const ValueType& value) const = 0;
+  virtual double cluster_or_prior_logp(std::mt19937* prng, const T_items& items,
+                                       const ValueType& value) const = 0;
 
-  virtual ValueType sample_at_items(std::mt19937* prng, const T_items& items) const = 0;
+  virtual ValueType sample_at_items(std::mt19937* prng,
+                                    const T_items& items) const = 0;
 
-  virtual void incorporate_to_cluster(const T_items& items, const ValueType& value) = 0;
+  virtual void incorporate_sample(std::mt19937* prng, const T_items& items) = 0;
+
+  virtual void incorporate_to_cluster(const T_items& items,
+                                      const ValueType& value) = 0;
 
   virtual void unincorporate_from_cluster(const T_items& items) = 0;
 
   // TODO(emilyaf): Standardize passing PRNG first or last.
-  virtual std::vector<double> logp_gibbs_exact(
-      const Domain& domain, const T_item& item, std::vector<int> tables,
-      std::mt19937* prng) = 0;
+  virtual std::vector<double> logp_gibbs_exact(const Domain& domain,
+                                               const T_item& item,
+                                               std::vector<int> tables,
+                                               std::mt19937* prng) = 0;
 
-  virtual void set_cluster_assignment_gibbs(const Domain& domain, const T_item& item,
-                                            int table, std::mt19937* prng) = 0;
+  virtual void set_cluster_assignment_gibbs(const Domain& domain,
+                                            const T_item& item, int table,
+                                            std::mt19937* prng) = 0;
 
-  virtual void transition_cluster_hparams(std::mt19937* prng, int num_theta_steps) = 0;
+  virtual void transition_cluster_hparams(std::mt19937* prng,
+                                          int num_theta_steps) = 0;
 
-  // Accessor/convenience methods, mostly for subclass members that can't be accessed through the base class.
+  // Accessor/convenience methods, mostly for subclass members that can't be
+  // accessed through the base class.
   virtual const std::vector<Domain*>& get_domains() const = 0;
 
   virtual const ValueType& get_value(const T_items& items) const = 0;
 
-  virtual const std::unordered_map<const T_items, ValueType, H_items>& get_data() const = 0;
+  virtual const std::unordered_map<const T_items, ValueType, H_items>&
+  get_data() const = 0;
 
   virtual void update_value(const T_items& items, const ValueType& value) = 0;
 
-  virtual std::vector<int> get_cluster_assignment(const T_items& items) const = 0;
+  virtual std::vector<int> get_cluster_assignment(
+      const T_items& items) const = 0;
 
-  virtual bool has_observation(const Domain& domain, const T_item& item) const = 0;
+  virtual bool has_observation(const Domain& domain,
+                               const T_item& item) const = 0;
 
   // Convert a string to ValueType.
   ValueType from_string(const std::string& s) {
@@ -69,7 +83,6 @@ class Relation {
   };
 
   virtual ~Relation() = default;
-
 };
 
 

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -37,6 +37,7 @@ class Relation {
   virtual ValueType sample_at_items(std::mt19937* prng,
                                     const T_items& items) const = 0;
 
+  // Takes a sample from the cluster containing `items` and incorporates it.
   virtual void incorporate_sample(std::mt19937* prng, const T_items& items) = 0;
 
   virtual void incorporate_to_cluster(const T_items& items,


### PR DESCRIPTION
I added `incorporate_sample` to `Relation` instead of taking care of everything in HIRM in anticipation of it being useful for our eventual HIRM/PClean hybrid that will enforce a unique-valued index domain in samples as well.