### PR TITLE
Fix Relation::from_string for ValueType==std::string and add a test

### DIFF
--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -106,6 +106,7 @@ cc_library(
 cc_library(
     name = "relation",
     hdrs = ["relation.hh"],
+    srcs = ["relation.cc"],
     visibility = [":__subpackages__"],
     deps = [
         ":domain",

--- a/cxx/clean_relation_test.cc
+++ b/cxx/clean_relation_test.cc
@@ -1,6 +1,6 @@
 // Apache License, Version 2.0, refer to LICENSE.txt
 
-#define BOOST_TEST_MODULE test Relation
+#define BOOST_TEST_MODULE test clean_relation
 
 #include "clean_relation.hh"
 
@@ -176,4 +176,19 @@ BOOST_AUTO_TEST_CASE(test_cluster_logp_sample) {
   double sample = R1.sample_at_items(&prng, {0, 2});
   double lp = R1.cluster_or_prior_logp(&prng, {0, 2}, sample);
   BOOST_TEST(lp < 0.0);
+}
+
+BOOST_AUTO_TEST_CASE(test_from_string) {
+  std::mt19937 prng;
+  Domain D1("D1");
+  Domain D2("D2");
+  DistributionSpec spec("normal");
+  CleanRelation<double> R1("R1", spec, {&D1, &D2});
+  double d = R1.from_string("3.14159");
+  BOOST_TEST(d == 3.14159);
+
+  DistributionSpec spec2("bigram");
+  CleanRelation<std::string> R2("R2", spec2, {&D1, &D2});
+  std::string s = R2.from_string("hello world");
+  BOOST_TEST(s == "hello world");
 }

--- a/cxx/noisy_relation_test.cc
+++ b/cxx/noisy_relation_test.cc
@@ -1,6 +1,6 @@
 // Apache License, Version 2.0, refer to LICENSE.txt
 
-#define BOOST_TEST_MODULE test Relation
+#define BOOST_TEST_MODULE test noisy_relation
 
 #include "noisy_relation.hh"
 

--- a/cxx/relation.cc
+++ b/cxx/relation.cc
@@ -1,0 +1,6 @@
+#include "relation.hh"
+
+template <>
+std::string Relation<std::string>::from_string(const std::string& s) {
+  return s;
+}

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -71,3 +71,9 @@ class Relation {
   virtual ~Relation() = default;
 
 };
+
+
+// Overload from_string for ValueType=string because >> truncates at the first
+// space.
+template <>
+std::string Relation<std::string>::from_string(const std::string& s);


### PR DESCRIPTION
Fixes part of https://github.com/probcomp/hierarchical-irm/issues/151