### PR TITLE
Make -c opt mode build without warnings

### DIFF
--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -392,7 +392,11 @@ class CleanRelation : public Relation<T> {
   void set_cluster_assignment_gibbs(const Domain& domain, const T_item& item,
                                     int table, std::mt19937* prng) {
     int table_current = domain.get_cluster_assignment(item);
-    assert(table != table_current);
+    if (table == table_current) {
+      printf("table %d == table_current in set_cluster_assignment_gibbs\n",
+             table);
+      assert(false);
+    }
     for (const T_items& items : data_r.at(domain.name).at(item)) {
       ValueType x = data.at(items);
       // Remove from current cluster.

--- a/cxx/distributions/get_distribution.cc
+++ b/cxx/distributions/get_distribution.cc
@@ -61,7 +61,8 @@ DistributionSpec::DistributionSpec(
     distribution = DistributionEnum::string_skellam;
     observation_type = ObservationEnum::string_type;
   } else {
-    assert(false && "Unsupported distribution name.");
+    printf("Unknown distribution name %s\n", dist_name.c_str());
+    std::exit(1);
   }
 }
 
@@ -104,6 +105,7 @@ DistributionVariant get_prior(const DistributionSpec& spec,
       return new DistributionAdapter<int>(s);
     }
     default:
-      assert(false && "Unsupported distribution enum value.");
+      printf("Unknown distribution enum value %d.\n", (int)(spec.distribution));
+      std::exit(1);
   }
 }

--- a/cxx/emissions/base.hh
+++ b/cxx/emissions/base.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <cstdlib>
 #include <random>
 
 #include "distributions/base.hh"
@@ -9,7 +10,8 @@ template <typename SampleType = double>
 class Emission : public Distribution<std::pair<SampleType, SampleType>> {
  public:
   virtual std::pair<SampleType, SampleType> sample(std::mt19937* prng) {
-    assert(false && "sample() should never be called on an Emission\n");
+    printf("sample() should never be called on an Emission\n");
+    std::exit(1);
   }
 
   // Return a stochastically corrupted version of clean.

--- a/cxx/emissions/categorical.hh
+++ b/cxx/emissions/categorical.hh
@@ -50,7 +50,7 @@ class CategoricalEmission : public Emission<int> {
   int propose_clean(const std::vector<int>& corrupted,
                      std::mt19937* unused_prng) {
     // Brute force; compute log prob over all possible clean states.
-    int best_clean;
+    int best_clean = 0;
     double best_clean_logp = std::numeric_limits<double>::lowest();
     for (size_t i = 0; i < emission_dists.size(); ++i) {
       double lp = 0.0;

--- a/cxx/emissions/get_emission.cc
+++ b/cxx/emissions/get_emission.cc
@@ -4,6 +4,7 @@
 #include "emissions/get_emission.hh"
 
 #include <cassert>
+#include <cstdlib>
 #include <random>
 #include <string>
 
@@ -37,7 +38,8 @@ EmissionSpec::EmissionSpec(
     emission = EmissionEnum::sometimes_gaussian;
     observation_type = ObservationEnum::double_type;
   } else {
-    assert(false && "Unsupported emission name.");
+    printf("Unknown Emission name %s\n", emission_str.c_str());
+    std::exit(1);
   }
 }
 
@@ -59,6 +61,7 @@ EmissionVariant get_prior(const EmissionSpec& spec, std::mt19937* prng) {
     case EmissionEnum::sometimes_gaussian:
       return new Sometimes<double>(new GaussianEmission());
     default:
-      assert(false && "Unsupported emission enum value.");
+      printf("Unknown Emission enum value %d.\n", (int)(spec.emission));
+      std::exit(1);
   }
 }

--- a/cxx/emissions/simple_string.hh
+++ b/cxx/emissions/simple_string.hh
@@ -166,7 +166,7 @@ class SimpleStringEmission : public Emission<std::string> {
     while (true) {
       std::unordered_map<char, int> counts;
       int max_count = 0;
-      char mode;
+      char mode = '\0';
       for (const std::string& s : corrupted) {
         char c;
         if (i < s.length()) {

--- a/cxx/emissions/sometimes.hh
+++ b/cxx/emissions/sometimes.hh
@@ -78,7 +78,7 @@ class Sometimes : public Emission<SampleType> {
     // BetaBernoulli instances for each choice of clean and picking the
     // clean with the highest combined logp_score().
     std::unordered_map<SampleType, int> counts;
-    SampleType mode;
+    SampleType mode = corrupted[0];
     int max_count = 0;
     for (const SampleType& c : corrupted) {
       ++counts[c];

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -146,7 +146,9 @@ void HIRM::transition_cluster_assignment_relation(std::mt19937* prng,
   crp.incorporate(rc, choice);
   assert(irms.size() == crp.tables.size());
   for (const auto& [table, irm] : irms) {
-    assert(crp.tables.contains(table));
+    if (!crp.tables.contains(table)) {
+      assert(false);
+    }
   }
 
   // Update any parent relations to point to the new relation as a base
@@ -204,7 +206,9 @@ void HIRM::set_cluster_assignment_gibbs(std::mt19937* prng,
   update_base_relation(r);
   assert(irms.size() == crp.tables.size());
   for (const auto& [table, irm] : irms) {
-    assert(crp.tables.contains(table));
+    if (!crp.tables.contains(table)) {
+      assert(false);
+    }
   }
 }
 

--- a/cxx/irm.cc
+++ b/cxx/irm.cc
@@ -4,6 +4,7 @@
 #include "irm.hh"
 
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <functional>
 #include <variant>
@@ -21,7 +22,9 @@ RelationVariant clean_relation_from_spec(const std::string& name,
     case ObservationEnum::string_type:
       return new CleanRelation<std::string>(name, spec, doms);
     default:
-      assert(false && "Unsupported observation type.");
+      printf("Unknown observation type %d for relation %s\n",
+             (int)(spec.observation_type), name.c_str());
+      std::exit(1);
   }
 }
 

--- a/cxx/pclean/pclean.cc
+++ b/cxx/pclean/pclean.cc
@@ -2,7 +2,7 @@
 // Apache License, Version 2.0, refer to LICENSE.txt
 
 // Example usage:
-//   ./pclean --schema=assets/flights.schema --obs=assets/flights_dirty.csv \
+//   ./pclean --schema=assets/flights.schema --obs=assets/flights_dirty.csv
 //            --iters=5
 
 #include <iostream>

--- a/cxx/pclean/schema_helper.cc
+++ b/cxx/pclean/schema_helper.cc
@@ -74,6 +74,8 @@ PCleanVariable PCleanSchemaHelper::get_scalarvar_from_path(
   printf("Error: could not find name %s in class %s\n",
          s.c_str(), base_class.name.c_str());
   assert(false);
+  PCleanVariable pcv;
+  return pcv;
 }
 
 std::vector<std::string> reorder_domains(

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -80,14 +80,16 @@ int main(int argc, char** argv) {
 
   // Marginally normalized.
   int persiancat = enc["animal"]["persiancat"];
-  auto p0_black_persiancat = hirm.logp({{"black", {persiancat}, false}}, &prng);
-  auto p1_black_persiancat = hirm.logp({{"black", {persiancat}, true}}, &prng);
+  [[maybe_unused]] auto p0_black_persiancat = hirm.logp({{"black", {persiancat}, false}}, &prng);
+  [[maybe_unused]] auto p1_black_persiancat = hirm.logp({{"black", {persiancat}, true}}, &prng);
   assert(abs(logsumexp({p0_black_persiancat, p1_black_persiancat})) < 1e-10);
 
   // Marginally normalized.
   int sheep = enc["animal"]["sheep"];
-  auto p0_solitary_sheep = hirm.logp({{"solitary", {sheep}, false}}, &prng);
-  auto p1_solitary_sheep = hirm.logp({{"solitary", {sheep}, true}}, &prng);
+  [[maybe_unused]] auto p0_solitary_sheep = hirm.logp(
+      {{"solitary", {sheep}, false}}, &prng);
+  [[maybe_unused]] auto p1_solitary_sheep = hirm.logp(
+      {{"solitary", {sheep}, true}}, &prng);
   assert(abs(logsumexp({p0_solitary_sheep, p1_solitary_sheep})) < 1e-10);
 
   // Jointly normalized.
@@ -99,7 +101,7 @@ int main(int argc, char** argv) {
       {{"black", {persiancat}, true}, {"solitary", {sheep}, false}}, &prng);
   auto p11_black_persiancat_solitary_sheep = hirm.logp(
       {{"black", {persiancat}, true}, {"solitary", {sheep}, true}}, &prng);
-  auto Z = logsumexp({
+  [[maybe_unused]] auto Z = logsumexp({
       p00_black_persiancat_solitary_sheep,
       p01_black_persiancat_solitary_sheep,
       p10_black_persiancat_solitary_sheep,
@@ -133,7 +135,7 @@ int main(int argc, char** argv) {
     assert(abs(irx->logp_score() - irm->logp_score()) < 1e-8);
     // Check domains agree.
     for (const auto& [d, dm] : irm->domains) {
-      auto dx = irx->domains.at(d);
+      [[maybe_unused]] auto dx = irx->domains.at(d);
       assert(dm->items == dx->items);
       assert(dm->crp.assignments == dx->crp.assignments);
       assert(dm->crp.tables == dx->crp.tables);
@@ -150,7 +152,7 @@ int main(int argc, char** argv) {
       assert(rm->data_r == rx->data_r);
       assert(rm->clusters.size() == rx->clusters.size());
       for (const auto& [z, clusterm] : rm->clusters) {
-        auto clusterx = rx->clusters.at(z);
+        [[maybe_unused]] auto clusterx = rx->clusters.at(z);
         assert(clusterm->N == clusterx->N);
       }
     }

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -81,12 +81,12 @@ int main(int argc, char** argv) {
     auto p0 =
         reinterpret_cast<T_r>(std::get<Relation<bool>*>(irm.relations.at("R1")))
             ->logp({x1, x2}, false, &prng);
-    auto p0_irm = irm.logp({{"R1", {x1, x2}, false}}, &prng);
+    [[maybe_unused]] auto p0_irm = irm.logp({{"R1", {x1, x2}, false}}, &prng);
     assert(abs(p0 - p0_irm) < 1e-10);
     auto p1 =
         reinterpret_cast<T_r>(std::get<Relation<bool>*>(irm.relations.at("R1")))
             ->logp({x1, x2}, true, &prng);
-    auto Z = logsumexp({p0, p1});
+    [[maybe_unused]] auto Z = logsumexp({p0, p1});
     assert(abs(Z) < 1e-10);
     assert(abs(exp(p0) - expected_p0[x1].at(x2)) < .1);
   }
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
         irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, false}}, &prng);
     auto p11 =
         irm.logp({{"R1", {x1, x2}, true}, {"R1", {x1, x3}, true}}, &prng);
-    auto Z = logsumexp({p00, p01, p10, p11});
+    [[maybe_unused]] auto Z = logsumexp({p00, p01, p10, p11});
     assert(abs(Z) < 1e-10);
   }
 
@@ -134,8 +134,8 @@ int main(int argc, char** argv) {
   assert(abs(irx.logp_score() - irm.logp_score()) < 1e-8);
   // Check domains agree.
   for (const auto& d : {"D1", "D2"}) {
-    auto dm = irm.domains.at(d);
-    auto dx = irx.domains.at(d);
+    [[maybe_unused]] auto dm = irm.domains.at(d);
+    [[maybe_unused]] auto dx = irx.domains.at(d);
     assert(dm->items == dx->items);
     assert(dm->crp.assignments == dx->crp.assignments);
     assert(dm->crp.tables == dx->crp.tables);
@@ -152,7 +152,7 @@ int main(int argc, char** argv) {
     assert(rm->data_r == rx->data_r);
     assert(rm->clusters.size() == rx->clusters.size());
     for (const auto& [z, clusterm] : rm->clusters) {
-      auto clusterx = rx->clusters.at(z);
+      [[maybe_unused]] auto clusterx = rx->clusters.at(z);
       assert(clusterm->N == clusterx->N);
     }
   }

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -126,8 +126,8 @@ int main(int argc, char** argv) {
   irm4.domains.at("feature")->crp.alpha = irm3.domains.at("feature")->crp.alpha;
   assert(abs(irm3.logp_score() - irm4.logp_score()) < 1e-8);
   for (const auto& d : {"animal", "feature"}) {
-    auto d3 = irm3.domains.at(d);
-    auto d4 = irm4.domains.at(d);
+    [[maybe_unused]] auto d3 = irm3.domains.at(d);
+    [[maybe_unused]] auto d4 = irm4.domains.at(d);
     assert(d3->items == d4->items);
     assert(d3->crp.assignments == d4->crp.assignments);
     assert(d3->crp.tables == d4->crp.tables);
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
     assert(r3->data_r == r4->data_r);
     assert(r3->clusters.size() == r4->clusters.size());
     for (const auto& [z, cluster3] : r3->clusters) {
-      auto cluster4 = r4->clusters.at(z);
+      [[maybe_unused]] auto cluster4 = r4->clusters.at(z);
       assert(cluster3->N == cluster4->N);
     }
   }

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -106,7 +106,7 @@ T_schema load_schema(const std::string& path) {
           printf("Error parsing schema line %s: expected ',' or ']' after parameter definition\n", line.c_str());
           printf("Got %s of type %d instead\n",
                  tokens[i].val.c_str(), (int)(tokens[i].type));
-          assert(false);
+          std::exit(1);
         }
 
       } while (tokens[i].val == ",");
@@ -134,7 +134,7 @@ T_schema load_schema(const std::string& path) {
         printf("Error parsing schema line %s: expected ',' or ')' after domain\n", line.c_str());
         printf("Got %s of type %d instead\n",
                tokens[i].val.c_str(), (int)(tokens[i].type));
-        assert(false);
+        std::exit(1);
       }
     } while (tokens[i++].val == ",");
 
@@ -187,7 +187,7 @@ T_observations load_observations(const std::string& path, T_schema& schema) {
 
     if (!schema.contains(relname)) {
       printf("Can not find %s in schema\n", relname.c_str());
-      assert(false);
+      std::exit(1);
     }
 
     std::string word;
@@ -358,7 +358,7 @@ void incorporate_observations(std::mt19937* prng,
       if (!base_to_noisy.contains(noisy_name)) {
         if (!observations.contains(noisy_name)) {
           printf("Relation %s has no observations and is not the base of a noisy relation.\n", noisy_name.c_str());
-          assert(false);
+          std::exit(false);
         }
       }
       noisy_to_base[noisy_name] = base_name;
@@ -577,7 +577,9 @@ load_clusters_hirm(const std::string& path) {
 
   assert(relations.size() == irms.size());
   for (const auto& [t, rs] : relations) {
-    assert(irms.count(t) == 1);
+    if (irms.count(t) != 1) {
+      assert(false);
+    }
   }
   fp.close();
   return std::make_pair(relations, irms);

--- a/cxx/util_parse.cc
+++ b/cxx/util_parse.cc
@@ -22,7 +22,7 @@ bool tokenize(std::string line, std::vector<Token>* tokens) {
       t.val += c;
     } else if ((c == '"') || (c == '\'')) {  // Strings
       t.type = TokenType::string;
-      char sc;
+      char sc = '$';
       while (i < line.length()) {
         sc = line[i++];
         if (sc == c) { // End of string


### PR DESCRIPTION
Also and relatedly, replace assert(false) with std::exit(1) when the program really needs to end, because all assert's are removed in -c opt mode.