### PR TITLE
Restore old cluster file format for compatibility with python code

### DIFF
--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -510,23 +510,14 @@ load_clusters_hirm(const std::string& path) {
 
   std::string line;
   int irmc = 0;
-  // Only reset the IRM cluster when we see two newlines in a row.
-  bool start_of_irm_separator = false;
 
   while (std::getline(fp, line)) {
     std::istringstream stream(line);
-    // Skip a newline.
     if (line.size() == 0) {
-      if (start_of_irm_separator) {
-        irmc = -1;
-        start_of_irm_separator = false;
-      } else {
-        start_of_irm_separator = true;
-      }
+      // Start of new IRM
+      irmc = -1;
       continue;
     }
-
-    start_of_irm_separator = false;
 
     std::string first;
     stream >> first;

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -397,7 +397,7 @@ void to_txt(std::ostream& fp, const IRM& irm, const T_encoding& encoding) {
           fp << " ";
         }
       }
-      fp << "\n\n";
+      fp << "\n";
     }
   }
 }
@@ -418,7 +418,7 @@ void to_txt(std::ostream& fp, const HIRM& hirm, const T_encoding& encoding) {
     }
     fp << "\n";
   }
-  fp << "\n\n";
+  fp << "\n";
   // Write the IRMs.
   int j = 0;
   for (const auto& [table, rcs] : tables) {


### PR DESCRIPTION
Fixes https://github.com/probcomp/hierarchical-irm/issues/176