### PR TITLE
Add --heldout option to hirm to calculate the log likelihood of held out data

### DIFF
--- a/cxx/hirm_main.cc
+++ b/cxx/hirm_main.cc
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
       cxxopts::value<std::string>()->default_value(""))(
       "path", "base name of the .schema file", cxxopts::value<std::string>())(
       "heldout", "filename of held-out observations",
-      cxxopts::value<std::string>())(
+      cxxopts::value<std::string>()->default_value(""))(
       "rest", "rest",
       cxxopts::value<std::vector<std::string>>()->default_value({}));
   options.parse_positional({"path", "rest"});

--- a/cxx/pclean/pclean.cc
+++ b/cxx/pclean/pclean.cc
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
   std::cout << "Translating observations ...\n";
   T_observations observations = translate_observations(df, hirm_schema);
   std::cout << "Encoding observations ...\n";
-  T_encoding encoding = encode_observations(hirm_schema, observations);
+  T_encoding encoding = calculate_encoding(hirm_schema, observations);
   std::cout << "Incorporating observations ...\n";
   incorporate_observations(&prng, &hirm, encoding, observations);
 

--- a/cxx/tests/test_hirm_animals.cc
+++ b/cxx/tests/test_hirm_animals.cc
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
   printf("--- loaded schema --- \n");
   auto observations_unary = load_observations(path_obs, schema_unary);
   printf("--- loaded observations --- \n");
-  auto encoding_unary = encode_observations(schema_unary, observations_unary);
+  auto encoding_unary = calculate_encoding(schema_unary, observations_unary);
   printf("--- encoded observations --- \n");
 
   HIRM hirm(schema_unary, &prng);

--- a/cxx/tests/test_irm_two_relations.cc
+++ b/cxx/tests/test_irm_two_relations.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   std::string path_obs = path_base + ".obs";
   std::cout << "loading observations from " << path_obs << std::endl;
   auto observations = load_observations(path_obs, schema);
-  T_encoding encoding = encode_observations(schema, observations);
+  T_encoding encoding = calculate_encoding(schema, observations);
 
   IRM irm(schema);
   incorporate_observations(&prng, &irm, encoding, observations);

--- a/cxx/tests/test_misc.cc
+++ b/cxx/tests/test_misc.cc
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
 
   IRM irm3(schema);
   auto observations = load_observations("assets/animals.binary.obs", schema);
-  auto encoding = encode_observations(schema, observations);
+  auto encoding = calculate_encoding(schema, observations);
   auto item_to_code = std::get<0>(encoding);
   for (const auto& [relation, obs] : observations) {
     for (const auto& [items, value] : obs) {

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -281,6 +281,7 @@ void incorporate_observations_relation(
     std::mt19937* prng, const std::string& relation,
     std::variant<IRM*, HIRM*> h_irm, const T_encoded_observations& observations,
     std::unordered_map<std::string, std::string>& noisy_to_base,
+    std::unordered_map<std::string, std::unordered_set<T_items, H_items>>&
         relation_items,
     std::unordered_set<std::string>& completed_relations) {
   RelationVariant rel_var =

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -252,7 +252,6 @@ T_encoding calculate_encoding(
 T_encoded_observations encode_observations(
     const T_observations& observations, const T_encoding& encoding,
     std::variant<IRM*, HIRM*> h_irm) {
-  T_encoding_f item_to_code = std::get<0>(encoding);
   T_encoded_observations encoded_observations;
   T_encoding_f item_to_code = std::get<0>(encoding);
 
@@ -263,7 +262,7 @@ T_encoded_observations encode_observations(
         std::visit([&](const auto& tr) { return tr.domains; }, trel);
     for (const auto& [items, value] : obs) {
       T_items items_e;
-      for (int i = 0; i < items.size(); ++i) {
+      for (size_t i = 0; i < items.size(); ++i) {
         int code = item_to_code.at(domains[i]).at(items[i]);
         items_e.push_back(code);
       }
@@ -271,7 +270,7 @@ T_encoded_observations encode_observations(
     }
   }
 
-  return encoded_observations
+  return encoded_observations;
 }
 
 // Incorporates the observations of a single relation. If the relation is noisy,

--- a/cxx/util_io.hh
+++ b/cxx/util_io.hh
@@ -14,12 +14,23 @@ typedef std::unordered_map<std::string, std::vector<T_observation>> T_observatio
 typedef std::tuple<std::vector<int>, std::string> T_encoded_observation;
 typedef std::unordered_map<std::string, std::vector<T_encoded_observation>> T_encoded_observations;
 
-// disk IO
+// Load the schema file from path.  Exits if the schema file can't be parsed.
 T_schema load_schema(const std::string& path);
-T_observations load_observations(const std::string& path,
-                                 T_schema& schema);
-T_encoding encode_observations(const T_schema& schema,
-                               const T_observations& observations);
+
+// Load the observations from the CSV file at path.  Also marks all observed
+// relations in schema as is_observed = true.
+T_observations load_observations(const std::string& path, T_schema& schema);
+
+// Calculates an encoding for the observations: in the input T_observations,
+// domain values are denoted by strings, and the encoding maps those to/from
+// integers.
+T_encoding calculate_encoding(
+    const T_schema& schema, const T_observations& observations);
+
+// Returns the encoded version of the input observations.
+T_encoded_observations encode_observations(
+    const T_observations& observations, const T_encoding& encoding,
+    std::variant<IRM*, HIRM*> h_irm);
 
 void incorporate_observations_relation(
     std::mt19937* prng, const std::string& relation,

--- a/cxx/util_io_test.cc
+++ b/cxx/util_io_test.cc
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(test_incorporate_observations_irm) {
                                       {{"banana", "cat", "rhombus"}, "1.1"},
                                   }}};
 
-  T_encoding encoding = encode_observations(schema, observations);
+  T_encoding encoding = calculate_encoding(schema, observations);
   IRM* irm = new IRM(schema);
   std::mt19937 prng;
   incorporate_observations(&prng, irm, encoding, observations);
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(test_incorporate_observations_hirm) {
                                       {{"banana", "cat", "rhombus"}, "1.1"},
                                   }}};
 
-  T_encoding encoding = encode_observations(schema, observations);
+  T_encoding encoding = calculate_encoding(schema, observations);
   std::mt19937 prng;
   HIRM* hirm = new HIRM(schema, &prng);
   incorporate_observations(&prng, hirm, encoding, observations);


### PR DESCRIPTION
As part of this, rename the badly-named encode_observations to calculate_encoding so that we can add a new method encode_observations that actually does that.

Addresses part of https://github.com/probcomp/hierarchical-irm/issues/178