### PR TITLE
Fix translate_observation's entity assignments

### DIFF
--- a/cxx/pclean/pclean.cc
+++ b/cxx/pclean/pclean.cc
@@ -73,7 +73,9 @@ int main(int argc, char** argv) {
       result["only_final_emissions"].as<bool>(),
       result["record_class_is_clean"].as<bool>());
   std::cout << "Translating schema ...\n";
-  T_schema hirm_schema = schema_helper.make_hirm_schema();
+  std::map<std::string, std::vector<std::string>> annotated_domains_for_relations;
+  T_schema hirm_schema = schema_helper.make_hirm_schema(
+      &annotated_domains_for_relation);
 
   // Read observations
   std::cout << "Reading observations ...\n";
@@ -87,7 +89,8 @@ int main(int argc, char** argv) {
 
   // Incorporate observations.
   std::cout << "Translating observations ...\n";
-  T_observations observations = translate_observations(df, hirm_schema);
+  T_observations observations = translate_observations(
+      df, hirm_schema, annotated_domains_for_relation);
   std::cout << "Encoding observations ...\n";
   T_encoding encoding = encode_observations(hirm_schema, observations);
   std::cout << "Incorporating observations ...\n";

--- a/cxx/pclean/pclean.cc
+++ b/cxx/pclean/pclean.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
   std::cout << "Translating schema ...\n";
   std::map<std::string, std::vector<std::string>> annotated_domains_for_relations;
   T_schema hirm_schema = schema_helper.make_hirm_schema(
-      &annotated_domains_for_relation);
+      &annotated_domains_for_relations);
 
   // Read observations
   std::cout << "Reading observations ...\n";
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
   // Incorporate observations.
   std::cout << "Translating observations ...\n";
   T_observations observations = translate_observations(
-      df, hirm_schema, annotated_domains_for_relation);
+      df, hirm_schema, annotated_domains_for_relations);
   std::cout << "Encoding observations ...\n";
   T_encoding encoding = encode_observations(hirm_schema, observations);
   std::cout << "Incorporating observations ...\n";

--- a/cxx/pclean/pclean_lib.cc
+++ b/cxx/pclean/pclean_lib.cc
@@ -9,7 +9,9 @@
 #include "pclean/pclean_lib.hh"
 
 T_observations translate_observations(
-    const DataFrame& df, const T_schema &schema) {
+    const DataFrame& df, const T_schema &schema,
+    const std::map<std::string, std::vector<std::string>>
+    &annotated_domains_for_relations) {
   T_observations obs;
 
   for (const auto& col : df.data) {
@@ -44,12 +46,11 @@ T_observations translate_observations(
       std::vector<std::string> entities;
       for (size_t j = 0; j < num_domains; ++j) {
         // Give every row it's own universe of unique id's.
-        // TODO(thomaswc): Correctly handle the case when a row makes
-        // references to two or more different entities of the same type.
         // TODO(thomaswc): Discuss other options for handling this, such
         // as sampling the non-index domains from a CRP prior or specifying
         // additional CSV columns to use as foreign keys.
-        entities.push_back(std::to_string(i));
+        entities.push_back(annotated_domains_for_relations[col_name][j]
+                           + ":" + std::to_string(i));
       }
       obs[col_name].push_back(std::make_tuple(entities, val));
     }

--- a/cxx/pclean/pclean_lib.cc
+++ b/cxx/pclean/pclean_lib.cc
@@ -49,7 +49,7 @@ T_observations translate_observations(
         // TODO(thomaswc): Discuss other options for handling this, such
         // as sampling the non-index domains from a CRP prior or specifying
         // additional CSV columns to use as foreign keys.
-        entities.push_back(annotated_domains_for_relations[col_name][j]
+        entities.push_back(annotated_domains_for_relations.at(col_name)[j]
                            + ":" + std::to_string(i));
       }
       obs[col_name].push_back(std::make_tuple(entities, val));

--- a/cxx/pclean/pclean_lib.hh
+++ b/cxx/pclean/pclean_lib.hh
@@ -7,10 +7,13 @@
 #include "util_io.hh"
 #include "pclean/csv.hh"
 #include "pclean/pclean_lib.hh"
+#include "pclean/schema_helper.hh"
 
 // For each non-missing value in the DataFrame df, create an
 // observation in the returned T_observations.  The column name of the value
 // is used as the relation name, and each entity in each domain is given
 // its own unique value.
 T_observations translate_observations(
-    const DataFrame& df, const T_schema &schema);
+    const DataFrame& df, const T_schema &schema,
+    const std::map<std::string, std::vector<std::string>>
+    &annotated_domains_for_relation);

--- a/cxx/pclean/pclean_lib.hh
+++ b/cxx/pclean/pclean_lib.hh
@@ -7,7 +7,6 @@
 #include "util_io.hh"
 #include "pclean/csv.hh"
 #include "pclean/pclean_lib.hh"
-#include "pclean/schema_helper.hh"
 
 // For each non-missing value in the DataFrame df, create an
 // observation in the returned T_observations.  The column name of the value

--- a/cxx/pclean/pclean_lib_test.cc
+++ b/cxx/pclean/pclean_lib_test.cc
@@ -31,7 +31,14 @@ BOOST_AUTO_TEST_CASE(test_translate_observations) {
     {"State",
       T_noisy_relation{{"dCounty", "dObs"}, true, EmissionSpec("bigram"), "County:state"}}};
 
-  T_observations obs = translate_observations(df, schema);
+  std::map<std::string, std::vector<std::string>> annotated_domains_for_relations;
+  annotated_domains_for_relations["Room Type"] = {"county:County", "Obs"};
+  annotated_domains_for_relations["Monthly Rent"] = {"county:County", "Obs"};
+  annotated_domains_for_relations["County"] = {"county:County", "Obs"};
+  annotated_domains_for_relations["State"] = {"county:County", "Obs"};
+
+  T_observations obs = translate_observations(
+      df, schema, annotated_domains_for_relations);
 
   // Relations not corresponding to columns should be un-observed.
   BOOST_TEST(!obs.contains("County:name"));

--- a/cxx/pclean/schema_helper.hh
+++ b/cxx/pclean/schema_helper.hh
@@ -17,7 +17,12 @@ class PCleanSchemaHelper {
                      bool _only_final_emissions = false,
                      bool _record_class_is_clean = true);
 
-  T_schema make_hirm_schema();
+  // Translate the PCleanSchema into an HIRM T_schema.
+  // Also, fill annotated_domains_for_relation[r] with the vector of
+  // annotated domains for the relation r.
+  T_schema make_hirm_schema(
+      std::map<std::string, std::vector<std::string>>
+      *annotated_domains_for_relation);
 
   // The rest of these methods are conceptually private, but actually
   // public for testing.

--- a/cxx/pclean/schema_helper.hh
+++ b/cxx/pclean/schema_helper.hh
@@ -32,8 +32,11 @@ class PCleanSchemaHelper {
   void compute_domains_for(const std::string& name);
 
   void make_relations_for_queryfield(
-      const QueryField& f, const PCleanClass& c,
-      T_schema* schema);
+      const QueryField& f,
+      const PCleanClass& c,
+      T_schema* schema,
+      std::map<std::string, std::vector<std::string>>
+      *annotated_domains_for_relation);
 
   PCleanSchema schema;
   bool only_final_emissions;


### PR DESCRIPTION
Previously, all entities associated with a row got the same row-dependent id.  That doesn't do what we want in the case where a given class in the schema contains two different references to another class.  For example, if there was a 

class Person
  birth_city ~ City
  current_location ~ City

we would want each row of the CSV file to get different entities for birth_city and current_location.  This problem explictly comes up in the flights data, where each flight has four times (scheduled and actual times 
departure and arrival), each of type ~ Time.

This fixes that by having make_hirm_schema also compute an annotated_domains_for_relations map, and having translate_observations use that.