### PR TITLE
Add tests for sampling

### DIFF
--- a/cxx/distributions/beta_bernoulli_test.cc
+++ b/cxx/distributions/beta_bernoulli_test.cc
@@ -114,3 +114,30 @@ BOOST_AUTO_TEST_CASE(test_transition_hyperparameters) {
   // beta.
   BOOST_TEST(bb.alpha > bb.beta);
 }
+
+BOOST_AUTO_TEST_CASE(test_sample_and_log_prob) {
+  std::mt19937 prng;
+  BetaBernoulli bb;
+
+  for (int i = 0; i < 17; ++i) {
+    bb.incorporate(0);
+  }
+
+  for (int i = 0; i < 19; ++i) {
+    bb.incorporate(1);
+  }
+
+  std::vector<int> counts{0, 0};
+  const int num_samples = 100000;
+  for (int i = 0; i < num_samples; ++i) {
+    ++counts[bb.sample(&prng)];
+  }
+
+  double p = exp(bb.logp(0));
+
+  double stddev = sqrt((17 / 36. * 19 / 36.) / num_samples);
+
+  // Check that we are within 3 standard deviations
+  BOOST_TEST(abs(p - (1. * counts[0] / num_samples)) <= 3 * stddev);
+  BOOST_TEST(abs((1- p) - (1. * counts[1] / num_samples)) <= 3 * stddev);
+}

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -204,14 +204,7 @@ BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   BOOST_TEST(nd.m > 0.0);
 }
 
-double two_sided_ks_test(std::vector<double>& samples1, std::vector<double>& samples2) {
-  // Sort the samples to get CDFs.
-  std::sort(samples1.begin(), samples1.end());
-  std::sort(samples2.begin(), samples2.end());
-  // Compute the sup of the empirical CDFs.
-}
-
-BOOST_AUTO_TEST_CASE(sample_and_log_prob) {
+BOOST_AUTO_TEST_CASE(sample_agrees) {
   std::mt19937 prng;
   Normal nd;
 
@@ -224,16 +217,26 @@ BOOST_AUTO_TEST_CASE(sample_and_log_prob) {
   }
 
   std::vector<double> samples;
+
   const int num_samples = 100000;
   for (int i = 0; i < num_samples; ++i) {
     samples.emplace_back(nd.sample(&prng));
   }
 
-  std::sort(samples.begin(), samples.end());
+  double sum = std::accumulate(samples.begin(), samples.end(), 0.);
+  double mean = sum / samples.size();
 
-  // Compute the true CDF of the normal distribution.
+  std::vector<double> diff(samples.size());
+  std::transform(
+          samples.begin(),
+          samples.end(),
+          diff.begin(),
+          [mean](double x) { return x - mean;});
+  double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.);
+  double stddev = std::sqrt(sq_sum / samples.size());
 
-  // Compute the arti
-
-
+  // Check that mean and stddev agree with a normal inverse gamma model.
+  double mprime, sprime;
+  nd.posterior_hypers(&mprime, &sprime);
+  BOOST_TEST(mean == mprime, tt::tolerance(4e-3));
 }

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -238,5 +238,10 @@ BOOST_AUTO_TEST_CASE(sample_agrees) {
   // Check that mean and stddev agree with a normal inverse gamma model.
   double mprime, sprime;
   nd.posterior_hypers(&mprime, &sprime);
+  double scale_factor = nd.r + nd.N;
+  double actual_stddev = sqrt(
+          (sprime / 2.) / (((nd.v + nd.N) / 2. - 1.) *
+              scale_factor / (scale_factor + 1)));
   BOOST_TEST(mean == mprime, tt::tolerance(4e-3));
+  BOOST_TEST(stddev == actual_stddev, tt::tolerance(4e-3));
 }

--- a/cxx/distributions/normal_test.cc
+++ b/cxx/distributions/normal_test.cc
@@ -203,3 +203,37 @@ BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   nd.transition_hyperparameters(&prng);
   BOOST_TEST(nd.m > 0.0);
 }
+
+double two_sided_ks_test(std::vector<double>& samples1, std::vector<double>& samples2) {
+  // Sort the samples to get CDFs.
+  std::sort(samples1.begin(), samples1.end());
+  std::sort(samples2.begin(), samples2.end());
+  // Compute the sup of the empirical CDFs.
+}
+
+BOOST_AUTO_TEST_CASE(sample_and_log_prob) {
+  std::mt19937 prng;
+  Normal nd;
+
+  for (int i = 0; i < 17; i+=2) {
+    nd.incorporate(i);
+  }
+
+  for (int i = 0; i >= -31; i-=3) {
+    nd.incorporate(i);
+  }
+
+  std::vector<double> samples;
+  const int num_samples = 100000;
+  for (int i = 0; i < num_samples; ++i) {
+    samples.emplace_back(nd.sample(&prng));
+  }
+
+  std::sort(samples.begin(), samples.end());
+
+  // Compute the true CDF of the normal distribution.
+
+  // Compute the arti
+
+
+}

--- a/cxx/distributions/skellam_test.cc
+++ b/cxx/distributions/skellam_test.cc
@@ -66,3 +66,43 @@ BOOST_AUTO_TEST_CASE(transition_theta) {
 
   BOOST_TEST(sd.mu1 > sd.mu2);
 }
+
+// Enable when Bessel function is better behaved.
+// BOOST_AUTO_TEST_CASE(test_sample_and_log_prob) {
+//   std::mt19937 prng;
+//   Skellam sd;
+//   for (int i = 0; i < 100; ++i) {
+//     sd.incorporate(5);
+//     sd.incorporate(6);
+//     sd.incorporate(6);
+//     sd.incorporate(7);
+//   }
+// 
+//   for (int i = 0; i < 100; ++i) {
+//     sd.transition_theta(&prng);
+//   }
+// 
+//   std::map<int, int> counts;
+//   const int num_samples = 100000;
+//   for (int i = 0; i < num_samples; ++i) {
+//     double sample = sd.sample(&prng);
+//     if (counts.contains(sample)) {
+//       ++counts[sd.sample(&prng)];
+//     }
+//     else {
+//       counts[sd.sample(&prng)] = 1;
+//     }
+//   }
+// 
+//   std::map<int, double> probs;
+//   for (const auto& kv : counts) {
+//     probs[kv.first] = exp(sd.logp(kv.first));
+//   }
+//   double stddev = sqrt(sd.mu1 + sd.mu2);
+// 
+//   // Check that we are within 3 standard deviations
+//   for (const auto& kv : counts) {
+//     double approx_p = kv.second / num_samples;
+//     BOOST_TEST(abs(probs[kv.first] - approx_p) <= 3 * stddev);
+//   }
+// }

--- a/cxx/distributions/zero_mean_normal_test.cc
+++ b/cxx/distributions/zero_mean_normal_test.cc
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(sample_agrees) {
 
   std::vector<double> samples;
 
-  const int num_samples = 100000;
+  const int num_samples = 200000;
   for (int i = 0; i < num_samples; ++i) {
     samples.emplace_back(nd.sample(&prng));
   }
@@ -211,9 +211,9 @@ BOOST_AUTO_TEST_CASE(sample_agrees) {
   double stddev = std::sqrt(sq_sum / samples.size());
 
   // Check that mean agrees with a normal inverse gamma model.
-  BOOST_TEST(mean == 0., tt::tolerance(4e-3));
+  BOOST_TEST(mean == 0., tt::tolerance(5e-3));
   double alpha_n = nd.alpha + nd.N / 2.0;
   double beta_n = nd.beta + nd.var * nd.N;
   double t_variance = beta_n / alpha_n;
-  BOOST_TEST(stddev == alpha_n / (alpha_n - 1.) * t_variance, tt::tolerance(4e-3));
+  BOOST_TEST(stddev == sqrt(alpha_n / (alpha_n - 1.) * t_variance), tt::tolerance(5e-3));
 }

--- a/cxx/distributions/zero_mean_normal_test.cc
+++ b/cxx/distributions/zero_mean_normal_test.cc
@@ -178,3 +178,42 @@ BOOST_AUTO_TEST_CASE(transition_hyperparameters) {
   nd.transition_hyperparameters(&prng);
   BOOST_TEST(nd.beta > 1.0);
 }
+
+BOOST_AUTO_TEST_CASE(sample_agrees) {
+  std::mt19937 prng;
+  ZeroMeanNormal nd;
+
+  for (int i = 0; i < 17; i+=2) {
+    nd.incorporate(i);
+  }
+
+  for (int i = 0; i >= -31; i-=3) {
+    nd.incorporate(i);
+  }
+
+  std::vector<double> samples;
+
+  const int num_samples = 100000;
+  for (int i = 0; i < num_samples; ++i) {
+    samples.emplace_back(nd.sample(&prng));
+  }
+
+  double sum = std::accumulate(samples.begin(), samples.end(), 0.);
+  double mean = sum / samples.size();
+
+  std::vector<double> diff(samples.size());
+  std::transform(
+          samples.begin(),
+          samples.end(),
+          diff.begin(),
+          [mean](double x) { return x - mean;});
+  double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.);
+  double stddev = std::sqrt(sq_sum / samples.size());
+
+  // Check that mean agrees with a normal inverse gamma model.
+  BOOST_TEST(mean == 0., tt::tolerance(4e-3));
+  double alpha_n = nd.alpha + nd.N / 2.0;
+  double beta_n = nd.beta + nd.var * nd.N;
+  double t_variance = beta_n / alpha_n;
+  BOOST_TEST(stddev == alpha_n / (alpha_n - 1.) * t_variance, tt::tolerance(4e-3));
+}

--- a/cxx/util_math_test.cc
+++ b/cxx/util_math_test.cc
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(test_product) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(test_sample_from_logps) {
+BOOST_AUTO_TEST_CASE(test_sample_from_logps_single) {
   // One of these entries isn't like the others, ...
   std::vector<double> logps = {-1.0, -2.0, 20.0, -3.0};
   std::mt19937 prng;
@@ -129,4 +129,24 @@ BOOST_AUTO_TEST_CASE(test_sample_from_logps_all_small) {
   std::vector<double> logps = {-10.0, -20.0, -30.0, -40.0, -50.0};
   std::mt19937 prng;
   BOOST_TEST(0 == sample_from_logps(logps, &prng));
+}
+
+BOOST_AUTO_TEST_CASE(test_sample_from_logps) {
+  std::vector<double> probs = {0.3, 0.1, 0.05, 0.1, 0.24, 0.11, 0., 0.1};
+  std::vector<double> logps;
+  for (int i = 0; i < std::ssize(probs); ++i) {
+    // Ensure these are not normalized.
+    logps.emplace_back(log(probs[i]) - 2.);
+  }
+  std::mt19937 prng;
+  int num_samples = 100000;
+  std::vector<int> counts{0, 0, 0, 0, 0, 0, 0, 0};
+  for (int i = 0; i < num_samples; ++i) {
+    ++counts[sample_from_logps(logps, &prng)];
+  }
+  for (int i = 0; i < std::ssize(logps); ++i) {
+    double approx_p = (1. * counts[i]) / num_samples;
+    double stddev = sqrt(probs[i] * (1 - probs[i]) / num_samples);
+    BOOST_TEST(abs(probs[i] - approx_p) <= 3 * stddev);
+  }
 }


### PR DESCRIPTION
This PR adds tests for sampling distributions and for sampling from unnormalized logps.

- I opted out of doing the sample_and_log_prob style tests because we only had one continuous distribution. The rest were categorical / discrete so we could compare counts. For the NNIG distribution, we can compare some first and second order moments as a good enough test.

- I added a test for Skellam but there are some numeric issues so it is commented out. I will look in to it later to see if I can enable it (numeric issues with the Bessel function that it is using).