### PR TITLE
Add --samples to hirm binary

### DIFF
--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -61,6 +61,7 @@ cc_library(
     visibility = [":__subpackages__"],
     deps = [
         ":irm",
+        ":observations",
     ],
 )
 

--- a/cxx/BUILD
+++ b/cxx/BUILD
@@ -104,6 +104,12 @@ cc_library(
 )
 
 cc_library(
+    name = "observations",
+    hdrs = ["observations.hh"],
+    deps = [],
+)
+
+cc_library(
     name = "relation",
     hdrs = ["relation.hh"],
     srcs = ["relation.cc"],
@@ -131,6 +137,7 @@ cc_library(
     ],
     deps = [
         ":hirm_lib",
+        ":observations",
         ":util_parse",
     ],
 )

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -107,11 +107,12 @@ class CleanRelation : public Relation<T> {
     clusters.at(z)->incorporate(value);
   }
 
-  void incorporate_sample(std::mt19937* prng, const T_items& items) {
+  ValueType incorporate_sample(std::mt19937* prng, const T_items& items) {
     T_items z = incorporate_items(prng, items);
     ValueType value = sample_at_items(prng, items);
     data[items] = value;
     clusters.at(z)->incorporate(value);
+    return value;
   }
 
   void unincorporate(const T_items& items) {

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -88,8 +88,6 @@ class CleanRelation : public Relation<T> {
     assert(!data.contains(items));
     for (int i = 0; i < std::ssize(domains); ++i) {
       domains[i]->incorporate(prng, items[i]);
-      printf("DEBUG: in clean relation %s, adding item %d to domain %s\n",
-             name.c_str(), items[i], domains[i]->name.c_str());
       if (!data_r.at(domains[i]->name).contains(items[i])) {
         data_r.at(domains[i]->name)[items[i]] =
             std::unordered_set<T_items, H_items>();

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -107,7 +107,7 @@ class CleanRelation : public Relation<T> {
     clusters.at(z)->incorporate(value);
   }
 
-  ValueType incorporate_sample(std::mt19937* prng, const T_items& items) {
+  ValueType sample_and_incorporate(std::mt19937* prng, const T_items& items) {
     T_items z = incorporate_items(prng, items);
     ValueType value = sample_at_items(prng, items);
     data[items] = value;

--- a/cxx/clean_relation.hh
+++ b/cxx/clean_relation.hh
@@ -88,6 +88,8 @@ class CleanRelation : public Relation<T> {
     assert(!data.contains(items));
     for (int i = 0; i < std::ssize(domains); ++i) {
       domains[i]->incorporate(prng, items[i]);
+      printf("DEBUG: in clean relation %s, adding item %d to domain %s\n",
+             name.c_str(), items[i], domains[i]->name.c_str());
       if (!data_r.at(domains[i]->name).contains(items[i])) {
         data_r.at(domains[i]->name)[items[i]] =
             std::unordered_set<T_items, H_items>();

--- a/cxx/clean_relation_test.cc
+++ b/cxx/clean_relation_test.cc
@@ -199,9 +199,12 @@ BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
   Domain D2("D2");
   DistributionSpec spec("normal");
   CleanRelation<double> R1("R1", spec, {&D1, &D2});
-  R1.incorporate_sample(&prng, {0, 1});
-  R1.incorporate_sample(&prng, {0, 2});
-  R1.incorporate_sample(&prng, {5, 2});
+  double s = R1.incorporate_sample(&prng, {0, 1});
+  BOOST_TEST(s < 100.0);
+  s = R1.incorporate_sample(&prng, {0, 2});
+  BOOST_TEST(s < 100.0);
+  s = R1.incorporate_sample(&prng, {5, 2});
+  BOOST_TEST(s < 100.0);
 
   BOOST_TEST(R1.data.size() == 3);
 }

--- a/cxx/clean_relation_test.cc
+++ b/cxx/clean_relation_test.cc
@@ -193,17 +193,17 @@ BOOST_AUTO_TEST_CASE(test_from_string) {
   BOOST_TEST(s == "hello world");
 }
 
-BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
+BOOST_AUTO_TEST_CASE(test_sample_and_incorporate) {
   std::mt19937 prng;
   Domain D1("D1");
   Domain D2("D2");
   DistributionSpec spec("normal");
   CleanRelation<double> R1("R1", spec, {&D1, &D2});
-  double s = R1.incorporate_sample(&prng, {0, 1});
+  double s = R1.sample_and_incorporate(&prng, {0, 1});
   BOOST_TEST(s < 100.0);
-  s = R1.incorporate_sample(&prng, {0, 2});
+  s = R1.sample_and_incorporate(&prng, {0, 2});
   BOOST_TEST(s < 100.0);
-  s = R1.incorporate_sample(&prng, {5, 2});
+  s = R1.sample_and_incorporate(&prng, {5, 2});
   BOOST_TEST(s < 100.0);
 
   BOOST_TEST(R1.data.size() == 3);

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -331,10 +331,10 @@ std::string HIRM::sample_and_incorporate_relation(
         },
         get_relation(r));
   }
-  std::string value;
-  std::visit([&](auto rel) { value = rel->incorporate_sample(prng, items); },
+  std::ostringstream ss;
+  std::visit([&](auto rel) { ss << rel->incorporate_sample(prng, items); },
              get_relation(r));
-  return value;
+  return ss.ostr();
 }
 
 T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -334,7 +334,7 @@ std::string HIRM::sample_and_incorporate_relation(
   std::ostringstream ss;
   std::visit([&](auto rel) { ss << rel->incorporate_sample(prng, items); },
              get_relation(r));
-  return ss.ostr();
+  return ss.str();
 }
 
 T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
@@ -359,7 +359,7 @@ T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
             [&](auto rel) { return rel->get_data().contains(entities); },
             get_relation(r));
         if (!r_contains_items) {
-          value = sample_and_incorporate_relation(prng, r, entities);
+          std::string value = sample_and_incorporate_relation(prng, r, entities);
           ++num_samples;
           obs[r].push_back(std::make_tuple(entities, value));
         }

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -341,12 +341,14 @@ T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
   T_encoded_observations obs;
   std::map<std::string, CRP> domain_crps;
   for (const auto& [r, spec] : schema) {
+    printf("Generating samples for relation %s\n", r.c_str());
     // If the relation is a leaf, sample n observations of it.
     if (!base_to_noisy_relations.contains(r)) {
       const std::vector<std::string>& r_domains =
           std::visit([](auto trel) { return trel.domains; }, spec);
       int num_samples = 0;
       while (num_samples < n) {
+        printf("Trying to generate sample #%d\n", num_samples);
         std::vector<int> entities;
         entities.reserve(r_domains.size());
         for (auto it = r_domains.cbegin(); it != r_domains.cend(); ++it) {
@@ -362,6 +364,12 @@ T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
           std::string value = sample_and_incorporate_relation(prng, r, entities);
           ++num_samples;
           obs[r].push_back(std::make_tuple(entities, value));
+        } else {
+          printf("Already contains entities (");
+          for (const auto &e : entities) {
+            printf("%d ", e);
+          }
+          printf(")\n");
         }
       }
     }

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -347,20 +347,18 @@ T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
   for (const auto& [unused_cluster_id, irm] : irms) {
     for (const auto& [domain_name, domain] : irm->domains) {
       for (const auto& [item, table] : domain->crp.assignments) {
-        domain_crps[domain_name].incorporate(item, table);
-        printf("Debug: added (%d, %d) to domain %s\n", item, table, domain_name.c_str());
+        int crp_item = domain_crps[domain_name].assignments.size();
+        domain_crps[domain_name].incorporate(crp_item, item);
       }
     }
   }
   for (const auto& [r, spec] : schema) {
-    printf("Generating samples for relation %s\n", r.c_str());
     // If the relation is a leaf, sample n observations of it.
     if (!base_to_noisy_relations.contains(r)) {
       const std::vector<std::string>& r_domains =
           std::visit([](auto trel) { return trel.domains; }, spec);
       int num_samples = 0;
       while (num_samples < n) {
-        printf("Trying to generate sample #%d\n", num_samples);
         std::vector<int> entities;
         entities.reserve(r_domains.size());
         std::vector<std::pair<std::string, int>> domain_and_crps;
@@ -384,9 +382,7 @@ T_encoded_observations HIRM::sample_and_incorporate(std::mt19937* prng, int n) {
           for (size_t i = 0; i < entities.size(); ++i) {
             domain_crps[domain_and_crps[i].first].unincorporate(
                 domain_and_crps[i].second);
-            printf("Debug: removed %s: %d \n", domain_and_crps[i].first.c_str(), domain_and_crps[i].second);
           }
-          std::exit(-1);
         }
       }
     }

--- a/cxx/hirm.cc
+++ b/cxx/hirm.cc
@@ -332,7 +332,7 @@ std::string HIRM::sample_and_incorporate_relation(
         get_relation(r));
   }
   std::ostringstream ss;
-  std::visit([&](auto rel) { ss << rel->incorporate_sample(prng, items); },
+  std::visit([&](auto rel) { ss << rel->sample_and_incorporate(prng, items); },
              get_relation(r));
   return ss.str();
 }

--- a/cxx/hirm.hh
+++ b/cxx/hirm.hh
@@ -10,6 +10,7 @@
 
 #include "distributions/get_distribution.hh"
 #include "irm.hh"
+#include "observations.hh"
 #include "relation.hh"
 #include "transition_latent_value.hh"
 
@@ -70,13 +71,14 @@ class HIRM {
   // of values from non-leaf relations as needed to get to `n` leaf samples.
   // Beware: since `n` unique values are sampled from CRPs, if `n` is too high
   // relative to the CRP `alpha`s, this function might take a very long time.
-  void sample_and_incorporate(std::mt19937* prng, int n);
+  // Returns the sampled relations.
+  T_encoded_observations sample_and_incorporate(std::mt19937* prng, int n);
 
   // Incorporates a sample into relation `r`. If `r` is a noisy relation, this
   // function recursively incorporates a sample into the base relation, if
-  // necessary.
-  void sample_and_incorporate_relation(std::mt19937* prng, const std::string& r,
-                                       T_items& items);
+  // necessary.  Returns the sample value as a string.
+  std::string sample_and_incorporate_relation(
+      std::mt19937* prng, const std::string& r, T_items& items);
 
   ~HIRM();
 

--- a/cxx/hirm_main.cc
+++ b/cxx/hirm_main.cc
@@ -24,6 +24,8 @@ int main(int argc, char** argv) {
       cxxopts::value<bool>()->default_value("false"))(
       "timeout", "number of seconds of inference",
       cxxopts::value<int>()->default_value("0"))(
+      "samples", "number of samples to write to disk",
+      cxxopts::value<int>()->default_value("0"))(
       "load", "path to .[h]irm file with initial clusters",
       cxxopts::value<std::string>()->default_value(""))(
       "path", "base name of the .schema file", cxxopts::value<std::string>())(
@@ -49,6 +51,7 @@ int main(int argc, char** argv) {
   int iters = result["iters"].as<int>();
   int timeout = result["timeout"].as<int>();
   bool verbose = result["verbose"].as<bool>();
+  int num_samples = result["samples"].as<int>();
   std::string path_clusters = result["load"].as<std::string>();
   std::string mode = result["mode"].as<std::string>();
 
@@ -112,6 +115,10 @@ int main(int argc, char** argv) {
       std::cout << "Log likelihood of held out data is " << lp << std::endl;
     }
 
+    if (num_samples > 0) {
+      std::cout << "Sorry, IRM does not currently support generating samples\n";
+    }
+
     // Free
     free(irm);
     return 0;
@@ -142,6 +149,14 @@ int main(int argc, char** argv) {
     if (!held_out.empty()) {
       double lp = logp(&prng, hirm, encoding, heldout_obs);
       std::cout << "Log likelihood of held out data is " << lp << std::endl;
+    }
+
+    if (num_samples > 0) {
+      std::cout << "Generating " << num_samples << " samples\n";
+      T_encoded_observations sampled_obs = hirm->sample_and_incorporate(
+          &prng, num_samples);
+      std::cout << "Writing samples ...\n";
+      write_observations(path_save + ".samples", sampled_obs, encoding, hirm);
     }
 
     // Free

--- a/cxx/hirm_test.cc
+++ b/cxx/hirm_test.cc
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_hirm_sample) {
 
   std::mt19937 prng;
   HIRM hirm(schema2, &prng);
-  hirm.sample_and_incorporate(&prng, 5);
+  T_encoded_observations samples = hirm.sample_and_incorporate(&prng, 5);
 
   BOOST_TEST(
       std::get<Relation<bool>*>(hirm.get_relation("R2"))->get_data().size() ==
@@ -106,6 +106,10 @@ BOOST_AUTO_TEST_CASE(test_hirm_sample) {
   BOOST_TEST(nobs_R4 > 0);
   BOOST_TEST(nobs_R4 <= 5);
   BOOST_TEST(hirm.logp_score() < 0.0);
+
+  BOOST_TEST(samples.at("R2").size() == 5);
+  BOOST_TEST(samples.at("R3").size() == 5);
+  BOOST_TEST(samples.at("R5").size() == 5);
 }
 
 BOOST_AUTO_TEST_CASE(test_hirm_relation_names) {

--- a/cxx/integration_tests.sh
+++ b/cxx/integration_tests.sh
@@ -15,7 +15,7 @@ endt1=$(date +%s)
 bazel build -c opt :hirm pclean:pclean
 ./bazel-bin/hirm --mode=irm --iters=5 assets/animals.binary
 startt2=$(date +%s)
-./bazel-bin/hirm --seed=1 --iters=5 assets/animals.unary
+./bazel-bin/hirm --seed=1 --iters=5 assets/animals.unary --samples=5
 ./bazel-bin/hirm --iters=5 --load=assets/animals.unary.1.hirm assets/animals.unary
 endt2=$(date +%s)
 startt3=$(date +%s)

--- a/cxx/noisy_relation.hh
+++ b/cxx/noisy_relation.hh
@@ -68,7 +68,7 @@ class NoisyRelation : public Relation<T> {
     base_to_noisy_items[base_items].insert(items);
   }
 
-  ValueType incorporate_sample(std::mt19937* prng, const T_items& items) {
+  ValueType sample_and_incorporate(std::mt19937* prng, const T_items& items) {
     T_items z = emission_relation.incorporate_items(prng, items);
     const ValueType& base_val = get_base_value(items);
     ValueType value = sample_at_items(prng, items);

--- a/cxx/noisy_relation.hh
+++ b/cxx/noisy_relation.hh
@@ -68,13 +68,14 @@ class NoisyRelation : public Relation<T> {
     base_to_noisy_items[base_items].insert(items);
   }
 
-  void incorporate_sample(std::mt19937* prng, const T_items& items) {
+  ValueType incorporate_sample(std::mt19937* prng, const T_items& items) {
     T_items z = emission_relation.incorporate_items(prng, items);
     const ValueType& base_val = get_base_value(items);
     ValueType value = sample_at_items(prng, items);
     data[items] = value;
     emission_relation.clusters.at(z)->incorporate(
         std::make_pair(base_val, value));
+    return value;
   }
 
   // incorporate_to_cluster and unincorporate_from_cluster should be used with

--- a/cxx/noisy_relation_test.cc
+++ b/cxx/noisy_relation_test.cc
@@ -203,9 +203,12 @@ BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
   EmissionSpec em_spec("sometimes_gaussian");
   NoisyRelation<double> NR1("NR1", em_spec, {&D1, &D2, &D3}, &R1);
 
-  NR1.incorporate_sample(&prng, {0, 1, 1});
-  NR1.incorporate_sample(&prng, {0, 1, 5});
-  NR1.incorporate_sample(&prng, {0, 1, 2});
+  double s = NR1.incorporate_sample(&prng, {0, 1, 1});
+  BOOST_TEST(s < 100.0);
+  s = NR1.incorporate_sample(&prng, {0, 1, 5});
+  BOOST_TEST(s < 100.0);
+  s = NR1.incorporate_sample(&prng, {0, 1, 2});
+  BOOST_TEST(s < 100.0);
 
   BOOST_TEST(NR1.data.size() == 3);
   BOOST_TEST(R1.data.size() == 1);

--- a/cxx/noisy_relation_test.cc
+++ b/cxx/noisy_relation_test.cc
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(test_cluster_logp_sample) {
   BOOST_TEST(lp < 0.0);
 }
 
-BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
+BOOST_AUTO_TEST_CASE(test_sample_and_incorporate) {
   std::mt19937 prng;
   Domain D1("D1");
   Domain D2("D2");
@@ -203,11 +203,11 @@ BOOST_AUTO_TEST_CASE(test_incorporate_sample) {
   EmissionSpec em_spec("sometimes_gaussian");
   NoisyRelation<double> NR1("NR1", em_spec, {&D1, &D2, &D3}, &R1);
 
-  double s = NR1.incorporate_sample(&prng, {0, 1, 1});
+  double s = NR1.sample_and_incorporate(&prng, {0, 1, 1});
   BOOST_TEST(s < 100.0);
-  s = NR1.incorporate_sample(&prng, {0, 1, 5});
+  s = NR1.sample_and_incorporate(&prng, {0, 1, 5});
   BOOST_TEST(s < 100.0);
-  s = NR1.incorporate_sample(&prng, {0, 1, 2});
+  s = NR1.sample_and_incorporate(&prng, {0, 1, 2});
   BOOST_TEST(s < 100.0);
 
   BOOST_TEST(NR1.data.size() == 3);

--- a/cxx/observations.hh
+++ b/cxx/observations.hh
@@ -1,0 +1,27 @@
+// Copyright 2024
+// See LICENSE.txt
+
+#pragma once
+
+#include <map>
+#include <tuple>
+#include <string>
+#include <vector>
+
+// A T_observation is a <list_of_entity_ids, value>.  It does not store the
+// relation it an observation of.  The i-th entity of the observation should
+// belong to the i-th domain of the relation, as specified in the schema.  The
+// value is stored as a string; you can use Relation::from_string to convert it
+// to the appropriate ValueType.
+typedef std::tuple<std::vector<std::string>, std::string> T_observation;
+
+// T_observations[relation_name] stores the T_observation's for that relation.
+typedef std::unordered_map<std::string, std::vector<T_observation>> T_observations;
+
+// Like a T_observation, but the entity_id's have been encoded down into
+// int's.
+typedef std::tuple<std::vector<int>, std::string> T_encoded_observation;
+
+// T_encoded_observations[relation_name] stores the T_encoded_observation's
+// for that relation.
+typedef std::unordered_map<std::string, std::vector<T_encoded_observation>> T_encoded_observations;

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -38,7 +38,9 @@ class Relation {
                                     const T_items& items) const = 0;
 
   // Takes a sample from the cluster containing `items` and incorporates it.
-  virtual void incorporate_sample(std::mt19937* prng, const T_items& items) = 0;
+  // Returns the sampled value.
+  virtual ValueType incorporate_sample(
+      std::mt19937* prng, const T_items& items) = 0;
 
   virtual void incorporate_to_cluster(const T_items& items,
                                       const ValueType& value) = 0;

--- a/cxx/relation.hh
+++ b/cxx/relation.hh
@@ -39,7 +39,7 @@ class Relation {
 
   // Takes a sample from the cluster containing `items` and incorporates it.
   // Returns the sampled value.
-  virtual ValueType incorporate_sample(
+  virtual ValueType sample_and_incorporate(
       std::mt19937* prng, const T_items& items) = 0;
 
   virtual void incorporate_to_cluster(const T_items& items,

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -221,7 +221,14 @@ void write_observations(
     for (const auto& [entities, value_str]: obs_for_rel) {
       fp << value_str << "," << rel;
       for (size_t i = 0; i < entities.size(); ++i) {
-        fp << "," << reverse_encoding.at(domains[i]).at(entities[i]);
+        fp << ",";
+        const auto& rev_encoding = reverse_encoding.at(domains[i]);
+        auto it = rev_encoding.find(entities[i]);
+        if (it == rev_encoding.end()) {
+          fp << "new_" << domains[i] << "_" << entities[i];
+        } else {
+          fp << it->second;
+        }
       }
       fp << "\n";
     }

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -212,10 +212,10 @@ T_observations load_observations(const std::string& path, T_schema& schema) {
 void write_observations(
     std::ostream& fp, const T_encoded_observations& observations,
     const T_encoding& encoding, std::variant<IRM*, HIRM*> h_irm) {
-  const T_encoding_r& reverse_encoding = encoding.second;
+  const T_encoding_r& reverse_encoding = std::get<1>(encoding);
   for (const auto& [rel, obs_for_rel]: observations) {
     T_relation trel = std::visit(
-        [&](const auto& m) { return m->schema.at(relation); }, h_irm);
+        [&](const auto& m) { return m->schema.at(rel); }, h_irm);
     std::vector<std::string> domains =
         std::visit([&](const auto& tr) { return tr.domains; }, trel);
     for (const auto& [entities, value_str]: obs_for_rel) {

--- a/cxx/util_io.cc
+++ b/cxx/util_io.cc
@@ -211,7 +211,7 @@ T_observations load_observations(const std::string& path, T_schema& schema) {
 
 void write_observations(
     std::ostream& fp, const T_encoded_observations& observations,
-    const& T_encoding encoding, std::variant<IRM*, HIRM*> h_irm) {
+    const T_encoding& encoding, std::variant<IRM*, HIRM*> h_irm) {
   const T_encoding_r& reverse_encoding = encoding.second;
   for (const auto& [rel, obs_for_rel]: observations) {
     T_relation trel = std::visit(
@@ -230,7 +230,7 @@ void write_observations(
 
 void write_observations(
     const std::string& path, const T_encoded_observations& observations,
-    const& T_encoding encoding, std::variant<IRM*, HIRM*> h_irm) {
+    const T_encoding& encoding, std::variant<IRM*, HIRM*> h_irm) {
   std::ofstream fp(path);
   assert(fp.good());
   write_observations(fp, observations, encoding, h_irm);

--- a/cxx/util_io.hh
+++ b/cxx/util_io.hh
@@ -4,15 +4,11 @@
 #pragma once
 
 #include "hirm.hh"
+#include "observations.hh"
 
 typedef std::map<std::string, std::map<std::string, T_item>> T_encoding_f;
 typedef std::map<std::string, std::map<T_item, std::string>> T_encoding_r;
 typedef std::tuple<T_encoding_f, T_encoding_r> T_encoding;
-
-typedef std::tuple<std::vector<std::string>, std::string> T_observation;
-typedef std::unordered_map<std::string, std::vector<T_observation>> T_observations;
-typedef std::tuple<std::vector<int>, std::string> T_encoded_observation;
-typedef std::unordered_map<std::string, std::vector<T_encoded_observation>> T_encoded_observations;
 
 // Load the schema file from path.  Exits if the schema file can't be parsed.
 T_schema load_schema(const std::string& path);
@@ -20,6 +16,11 @@ T_schema load_schema(const std::string& path);
 // Load the observations from the CSV file at path.  Also marks all observed
 // relations in schema as is_observed = true.
 T_observations load_observations(const std::string& path, T_schema& schema);
+
+// Write the observations to path.
+void write_observations(
+    const std::string& path, const T_encoded_observations& observations,
+    const& T_encoding encoding);
 
 // Calculates an encoding for the observations: in the input T_observations,
 // domain values are denoted by strings, and the encoding maps those to/from

--- a/cxx/util_io.hh
+++ b/cxx/util_io.hh
@@ -20,7 +20,7 @@ T_observations load_observations(const std::string& path, T_schema& schema);
 // Write the observations to path.
 void write_observations(
     const std::string& path, const T_encoded_observations& observations,
-    const& T_encoding encoding);
+    const T_encoding& encoding, std::variant<IRM*, HIRM*> h_irm);
 
 // Calculates an encoding for the observations: in the input T_observations,
 // domain values are denoted by strings, and the encoding maps those to/from


### PR DESCRIPTION
This PR is not ready to check in yet, because actually using --samples is way too slow in practice.  For example, the integration test in this PR

/bazel-bin/hirm --seed=1 --iters=5 assets/animals.unary --samples=5

currently hangs for over ten minutes.

However, I believe that is a problem in the current implementation of HIRM::sample_and_incorporate rather than anything this PR adds.

If/when this PR is submitted, it will address https://github.com/probcomp/hierarchical-irm/issues/178