### PR TITLE
Add visualization of binary relations

### DIFF
--- a/py/hirm_io.py
+++ b/py/hirm_io.py
@@ -8,8 +8,8 @@ Observation = collections.namedtuple(
 
 Cluster = collections.namedtuple(
     "Cluster", ["cluster_id", "relations", "domain_clusters"])
-Domain_Cluster = collections.namedtuple(
-    "Domain_Cluster", ["cluster_id", "domain", "entities"])
+DomainCluster = collections.namedtuple(
+    "DomainCluster", ["cluster_id", "domain", "entities"])
 
 def load_observations(path):
   """Load a dataset from path, and return it as an array of Observations."""
@@ -24,7 +24,7 @@ def load_observations(path):
   return data
 
 def load_clusters(path):
-  """Load the hirm clusters output from path as an HIRM_Clusters."""
+  """Load the hirm clusters output from path as a list of Cluster's."""
   id_to_relations = {}
   id_to_clusters = {}
 
@@ -55,9 +55,9 @@ def load_clusters(path):
         continue
 
       domain_clusters.append(
-          Domain_Cluster(cluster_id=fields[1],
-                         domain=fields[0],
-                         entities=fields[2:]))
+          DomainCluster(cluster_id=fields[1],
+                        domain=fields[0],
+                        entities=fields[2:]))
 
     id_to_clusters[cluster_id] = domain_clusters
 

--- a/py/make_plots.py
+++ b/py/make_plots.py
@@ -1,12 +1,20 @@
 #!/usr/bin/python3
 
+# Generates an html file containing plots that visualize the clusters
+# produced by an HIRM.  Currently it only supports datasets with a single
+# domain, and only visualizes the unary and binary relations over that
+# domain.
+
+# Example usage:
+#   ./make_plots.py --observations=../cxx/assets/animals.unary.obs --clusters=../cxx/assets/animals.unary.hirm --output=/tmp/vis.html
+
 import argparse
 import hirm_io
 import visualize
 
 def main():
   parser = argparse.ArgumentParser(
-      description="Generate matrix plots for a collection of unary relations")
+      description="Generate matrix plots for an HIRM's output")
   parser.add_argument(
       "--observations", required=True, type=str,
       help="Path to file containing observations")
@@ -25,7 +33,7 @@ def main():
   clusters = hirm_io.load_clusters(args.clusters)
 
   print(f"Writing html to {args.output} ...")
-  visualize.plot_unary_matrices(clusters, obs, args.output)
+  visualize.make_plots(clusters, obs, args.output)
 
 
 if __name__ == "__main__":

--- a/py/visualize.py
+++ b/py/visualize.py
@@ -171,5 +171,5 @@ def make_plots(clusters, obs, output):
     f.write("<html><body>\n\n")
     for cluster in clusters:
       f.write("<h1>IRM #" + cluster.cluster_id + "\n")
-      f.write(html_for_cluster(cluster, obs, clusters) + "\n)
+      f.write(html_for_cluster(cluster, obs, clusters) + "\n")
     f.write("</body></html>\n")

--- a/py/visualize_test.py
+++ b/py/visualize_test.py
@@ -17,21 +17,38 @@ class testVisualize(unittest.TestCase):
     html = visualize.figure_to_html(fig)
     self.assertEqual(html[:9], '<img src=')
 
-  def test_make_numpy_matrix(self):
+  def test_make_unary_matrix(self):
     observations = []
     observations.append(hirm_io.Observation(relation="R1", value="0", items=["A"]))
     observations.append(hirm_io.Observation(relation="R1", value="1", items=["B"]))
     observations.append(hirm_io.Observation(relation="R2", value="0", items=["A"]))
     observations.append(hirm_io.Observation(relation="R2", value="1", items=["B"]))
-    m = visualize.make_numpy_matrix(observations, ["A", "B"], ["R1", "R2"])
+    m = visualize.make_unary_matrix(observations, ["A", "B"], ["R1", "R2"])
     self.assertEqual(m.shape, (2, 2))
 
-  def test_normalize_matrix(self):
-    m = np.identity(3)
-    np.testing.assert_almost_equal(m, visualize.normalize_matrix(m))
-    np.testing.assert_almost_equal(m, visualize.normalize_matrix(3.0*m))
-    np.testing.assert_almost_equal([0, 0.25, 0.5, 0.75, 1.0],
-                                   visualize.normalize_matrix(np.arange(3, 8)))
+  def test_make_binary_matrix(self):
+    observations = []
+    observations.append(hirm_io.Observation(relation="R1", value="0", items=["A", "A"]))
+    observations.append(hirm_io.Observation(relation="R1", value="1", items=["B", "A"]))
+    observations.append(hirm_io.Observation(relation="R1", value="0", items=["A", "B"]))
+    observations.append(hirm_io.Observation(relation="R1", value="1", items=["B", "B"]))
+    m = visualize.make_binary_matrix(observations, ["A", "B"])
+    self.assertEqual(m.shape, (2, 2))
+
+  def test_get_all_entities(self):
+    c = hirm_io.Cluster(
+        cluster_id="1", relations=["R1"],
+        domain_clusters=[
+            hirm_io.DomainCluster(cluster_id="0", domain="animals",
+                                  entities=["dog", "cat", "elephant"]),
+            hirm_io.DomainCluster(cluster_id="1", domain="animals",
+                                  entities=["penguin"]),
+            hirm_io.DomainCluster(cluster_id="3", domain="animals",
+                                  entities=["mongoose", "eel", "human"])
+        ])
+    self.assertEqual(
+        ["cat", "dog", "elephant", "penguin", "eel", "human", "mongoose"],
+        visualize.get_all_entities(c))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
visualize_unary.py gets renamed to make_plots.py because it now makes all the unary and binary plots for a given HIRM run.

The other big change is that missing observations now get plotted in a different color than 0's.  I've chosen to plot them as white, and use a light color for 0's (and a dark color for 1's).  That's a different choice than the previous code base (and HIRM paper), which plotted missing observations as grey.  But I think that's a bad choice here because when plotting real valued observations, an intermediate value like 0.5 might also get displayed as grey.

Sample output:
![download](https://github.com/user-attachments/assets/23517674-c149-48fc-ae76-723114a74cce)
![download](https://github.com/user-attachments/assets/103e79bd-af0a-43b4-b1a5-90b12a76f13d)
