### PR TITLE
Add max_table method to CRP

### DIFF
--- a/cxx/distributions/crp.cc
+++ b/cxx/distributions/crp.cc
@@ -71,13 +71,13 @@ double CRP::logp_score() const {
 
 int CRP::max_table() const {
   if (N == 0) {
-    return 0;
+    return -1;
   }
   return tables.rbegin()->first;
 }
 
-std::unordered_map<int, double> CRP::tables_weights() const {
-  std::unordered_map<int, double> dist;
+std::map<int, double> CRP::tables_weights() const {
+  std::map<int, double> dist;
   if (N == 0) {
     dist[0] = 1;
     return dist;
@@ -89,14 +89,15 @@ std::unordered_map<int, double> CRP::tables_weights() const {
   return dist;
 }
 
-std::unordered_map<int, double> CRP::tables_weights_gibbs(int table) const {
+std::map<int, double> CRP::tables_weights_gibbs(int table) const {
   assert(N > 0);
   assert(tables.contains(table));
   auto dist = tables_weights();
   --dist.at(table);
   if (dist.at(table) == 0) {
     dist.at(table) = alpha;
-    dist.erase(max_table());
+    int t_max = dist.rbegin()->first;
+    dist.erase(t_max);
   }
   return dist;
 }

--- a/cxx/distributions/crp.cc
+++ b/cxx/distributions/crp.cc
@@ -69,18 +69,23 @@ double CRP::logp_score() const {
   return out;
 }
 
+int CRP::max_table() const {
+  if (N == 0) {
+    return 0;
+  }
+  return tables.rbegin()->first;
+}
+
 std::unordered_map<int, double> CRP::tables_weights() const {
   std::unordered_map<int, double> dist;
   if (N == 0) {
     dist[0] = 1;
     return dist;
   }
-  int t_max = 0;
   for (const auto& [table, customers] : tables) {
     dist[table] = customers.size();
-    t_max = std::max(table, t_max);
   }
-  dist[t_max + 1] = alpha;
+  dist[max_table() + 1] = alpha;
   return dist;
 }
 
@@ -91,11 +96,7 @@ std::unordered_map<int, double> CRP::tables_weights_gibbs(int table) const {
   --dist.at(table);
   if (dist.at(table) == 0) {
     dist.at(table) = alpha;
-    int t_max = 0;
-    for (const auto& [table, weight] : dist) {
-      t_max = std::max(table, t_max);
-    }
-    dist.erase(t_max);
+    dist.erase(max_table());
   }
   return dist;
 }

--- a/cxx/distributions/crp.hh
+++ b/cxx/distributions/crp.hh
@@ -32,11 +32,12 @@ class CRP {
 
   double logp_score() const;
 
+  // Returns the highest table entry in tables, or -1 if tables is empty.
   int max_table() const;
 
-  std::unordered_map<int, double> tables_weights() const;
+  std::map<int, double> tables_weights() const;
 
-  std::unordered_map<int, double> tables_weights_gibbs(int table) const;
+  std::map<int, double> tables_weights_gibbs(int table) const;
 
   void transition_alpha(std::mt19937* prng);
 };

--- a/cxx/distributions/crp.hh
+++ b/cxx/distributions/crp.hh
@@ -32,6 +32,8 @@ class CRP {
 
   double logp_score() const;
 
+  int max_table() const;
+
   std::unordered_map<int, double> tables_weights() const;
 
   std::unordered_map<int, double> tables_weights_gibbs(int table) const;

--- a/cxx/distributions/crp_test.cc
+++ b/cxx/distributions/crp_test.cc
@@ -16,7 +16,7 @@ namespace bm = boost::math;
 BOOST_AUTO_TEST_CASE(test_simple) {
   CRP crp;
 
-  BOOST_TEST(crp.max_table() == 0);
+  BOOST_TEST(crp.max_table() == -1);
 
   T_item cat = 1;
   T_item dog = 2;
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   BOOST_TEST(crp.tables.at(3).contains(dog));
 
   // Table weights are as expected.
-  std::unordered_map<int, double> tw = crp.tables_weights();
+  std::map<int, double> tw = crp.tables_weights();
   BOOST_TEST(tw.size() == 4);  // Three populated tables and one new one.
   BOOST_TEST(tw[0] == crp.tables.at(0).size());
   BOOST_TEST(tw[1] == crp.tables.at(1).size());
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   BOOST_TEST(tw[4] == crp.alpha);
 
   // Table weights gibbs is as expected.
-  std::unordered_map<int, double> twg = crp.tables_weights_gibbs(1);
+  std::map<int, double> twg = crp.tables_weights_gibbs(1);
   BOOST_TEST(tw[0] == twg[0]);
   BOOST_TEST(tw[1] == twg[1] + 1.);
   BOOST_TEST(tw[3] == twg[3]);

--- a/cxx/distributions/crp_test.cc
+++ b/cxx/distributions/crp_test.cc
@@ -16,6 +16,8 @@ namespace bm = boost::math;
 BOOST_AUTO_TEST_CASE(test_simple) {
   CRP crp;
 
+  BOOST_TEST(crp.max_table() == 0);
+
   T_item cat = 1;
   T_item dog = 2;
   T_item fish = 3;
@@ -30,6 +32,7 @@ BOOST_AUTO_TEST_CASE(test_simple) {
   crp.incorporate(hamster, 0);
   crp.incorporate(snake, 1);
   BOOST_TEST(crp.N == 6);
+  BOOST_TEST(crp.max_table() == 3);
 
   crp.unincorporate(cat);
   BOOST_TEST(crp.N == 5);

--- a/cxx/domain.hh
+++ b/cxx/domain.hh
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <cassert>
+#include <map>
 #include <string>
 #include <unordered_set>
 
@@ -44,10 +45,10 @@ class Domain {
     crp.unincorporate(item);
     crp.incorporate(item, table);
   }
-  std::unordered_map<int, double> tables_weights() const {
+  std::map<int, double> tables_weights() const {
     return crp.tables_weights();
   }
-  std::unordered_map<int, double> tables_weights_gibbs(
+  std::map<int, double> tables_weights_gibbs(
       const T_item& item) const {
     int table = get_cluster_assignment(item);
     return crp.tables_weights_gibbs(table);

--- a/cxx/gendb.cc
+++ b/cxx/gendb.cc
@@ -132,12 +132,7 @@ void GenDB::sample_and_incorporate_reference(
   auto [class_name, ref_field, class_item] = ref_key;
   int new_val;
   if (new_rows_have_unique_entities) {
-    auto it = domain_crps[ref_class].tables.rbegin();
-    if (it == domain_crps[ref_class].tables.rend()) {
-      new_val = 0;
-    } else {
-      new_val = it->first + 1;
-    }
+    new_val = domain_crps[ref_class].max_table() + 1;
   } else {
     new_val = domain_crps[ref_class].sample(prng);
   }

--- a/cxx/gendb.cc
+++ b/cxx/gendb.cc
@@ -582,7 +582,7 @@ void GenDB::transition_reference(std::mt19937* prng,
       std::get<ClassVar>(schema.classes.at(class_name).vars.at(ref_field).spec)
           .class_name;
   int init_refval = reference_values.at({class_name, ref_field, class_item});
-  std::unordered_map<int, double> crp_dist =
+  std::map<int, double> crp_dist =
       domain_crps[ref_class].tables_weights_gibbs(init_refval);
 
   // For each relation, get the indices (in the items vector) of the reference

--- a/cxx/gendb_test.cc
+++ b/cxx/gendb_test.cc
@@ -920,7 +920,7 @@ BOOST_AUTO_TEST_CASE(test_unincorporate_reincorporate_new) {
 
   // Now find the singleton value.
   int refval = -1;
-  std::unordered_map<int, double> crp_dist =
+  std::map<int, double> crp_dist =
       gendb.domain_crps[ref_class].tables_weights_gibbs(non_singleton_refval);
   for (auto [t, w] : crp_dist) {
     if (!gendb.domain_crps[ref_class].tables.contains(t)) {


### PR DESCRIPTION
and use it to make the code more understandable and more efficient.

Also, switch the table_weights() return values from unordered_map's to map's, so that their maximum key can be compute in O(1) time.